### PR TITLE
sexified user interface

### DIFF
--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -385,7 +385,7 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
 
   if (empty($options)) {
     $form['empty'] = array(
-      '#markup' => '<p>There are currently no IP address range lists defined. At least one IP address range list must be defined in order to create an IP embargo on this object.</p>',
+      '#markup' => '<p>There are currently no IP address range lists defined. At least one IP address range list must be defined in order to create IP embargoes.</p>',
     );
   }
   else {

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -203,8 +203,7 @@ function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifi
   }
 
   $form['name'] = array(
-    '#title' => t('Name'),
-    '#description' => t('Name of the list.'),
+    '#title' => t('List Name'),
     '#type' => 'textfield',
     '#required' => TRUE,
     '#default_value' => $list_name,
@@ -256,7 +255,7 @@ function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifi
   );
   $form['list_tabs']['list_embargoes']['delete_embargo'] = array(
     '#type' => 'submit',
-    '#value' => t('Delete embargos'),
+    '#value' => t('Delete embargoes'),
     '#submit' => array('islandora_ip_embargo_edit_list_form_embargo_submit'),
   );
   return $form;
@@ -433,6 +432,7 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
     );
 
     if ($embargo_result->rowCount()) {
+      $submit_button_value = t('Update Embargo');
       $form_state['storage']['islandora_ip_embargo']['update'] = TRUE;
       $form['lists']['#default_value'] = $embargo_info->lid;
       if (!isset($embargo_info->expiry)) {
@@ -449,8 +449,11 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
         );
       }
     }
+    else {
+      $submit_button_value = t('Set Embargo');
+    }
 
-    $form['submit'] = array('#type' => 'submit', '#value' => t('Set Embargo'));
+    $form['submit'] = array('#type' => 'submit', '#value' => $submit_button_value);
 
     if ($embargo_result->rowCount()) {
       $form['delete'] = array(

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -196,7 +196,7 @@ function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifi
       $expiry_date = t('None');
     }
     $embargo_options[$data->eid] = array(
-      'embargoed_object' => l($object->label, "islandora/object/{$data->pid}"),
+      'embargoed_object' => l($object->label, "islandora/object/{$data->pid}/ip_embargo"),
       'expiry_date' => $expiry_date,
       'object_pid' => $data->pid,
     );

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -392,8 +392,14 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
     $embargo_result = islandora_ip_embargo_get_embargo($islandora_object->id);
     $embargo_info = $embargo_result->fetchObject();
     if ($embargo_result->rowCount()) {
+      if (user_access('administer islandora ip embargoes')) {
+        $list = l($options[$embargo_info->lid], 'admin/islandora/ip_embargo/lists/' . $embargo_info->lid);
+      }
+      else {
+        $list = $options[$embargo_info->lid];
+      }
       if (!isset($embargo_info->expiry)) {
-        $embargo_message = t('This object is currently embargoed indefinitely.');
+        $embargo_message = t('This object is currently embargoed indefinitely against IP ranges defined in the list: ') . $list . '.';
         $form['current_embargo'] = array(
           '#markup' => '<p>' . $embargo_message . '</p><hr/>',
         );
@@ -403,7 +409,7 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
         $month = date('F', $embargo_info->expiry);
         $day = date('j', $embargo_info->expiry);
         $ordinal = date('S', $embargo_info->expiry);
-        $embargo_message = t("This object's embargo is set to expire on the @day@ordinal of @month, @year.", array(
+        $embargo_message = t("This object is embargoed against IP ranges defined in the list: ") . $list . '. ' . t("The embargo is set to expire on the @day@ordinal of @month, @year.", array(
           '@day' => $day,
           '@month' => $month,
           '@year' => $year,

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -168,14 +168,37 @@ function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifi
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   $list_information = islandora_ip_embargo_get_lists_information($list_identifier);
   $list_name = islandora_ip_embargo_get_list_name($list_identifier);
+  $embargo_information = islandora_ip_embargo_get_embargos($list_identifier);
   $form_state['storage']['islandora_ip_embargo']['list_identifier'] = $list_identifier;
-
-  $header = array('low_end' => t('low end'), 'high_end' => t('high end'));
-  $options = array();
+  $range_header = array('low_end' => t('low end'), 'high_end' => t('high end'));
+  $range_options = array();
   while ($data = $list_information->fetchObject()) {
-    $options[$data->rid] = array(
+    $range_options[$data->rid] = array(
       'high_end' => $data->high_end,
       'low_end' => $data->low_end,
+    );
+  }
+  $embargo_header = array(
+    'embargoed_object' => t('embargoed object'),
+    'expiry_date' => t('expiry date'),
+    'object_pid' => t('pid'),
+  );
+  $embargo_options = array();
+  while ($data = $embargo_information->fetchObject()) {
+    $object = islandora_object_load($data->pid);
+    if (isset($data->expiry)) {
+      $year = date('Y', $data->expiry);
+      $month = date('M', $data->expiry);
+      $day = date('j', $data->expiry);
+      $expiry_date = $day . '-' . $month . '-' . $year;
+    }
+    else {
+      $expiry_date = t('None');
+    }
+    $embargo_options[$data->eid] = array(
+      'embargoed_object' => l($object->label, "islandora/object/{$data->pid}"),
+      'expiry_date' => $expiry_date,
+      'object_pid' => $data->pid,
     );
   }
 
@@ -191,23 +214,50 @@ function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifi
     '#value' => t('Update name'),
     '#submit' => array('islandora_ip_embargo_edit_list_form_name_submit'),
   );
-  $form['ranges'] = array(
+  $form['list_tabs'] = array(
+    '#type' => 'vertical_tabs',
+  );
+  $form['list_tabs']['list_ranges'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Ranges'),
+  );
+  $form['list_tabs']['list_ranges']['ranges'] = array(
     '#type' => 'tableselect',
-    '#header' => $header,
-    '#options' => $options,
+    '#header' => $range_header,
+    '#options' => $range_options,
     '#attributes' => array(),
     '#empty' => t("There are no ranges."),
   );
-  $form['pager'] = array(
+  $form['list_tabs']['list_ranges']['pager'] = array(
     '#markup' => theme('pager'),
   );
-  $form['delete'] = array(
+  $form['list_tabs']['list_ranges']['delete_range'] = array(
     '#type' => 'submit',
     '#value' => t('Delete ranges'),
     '#submit' => array('islandora_ip_embargo_edit_list_form_range_submit'),
   );
-  $form['Add'] = array(
+  $form['list_tabs']['list_ranges']['Add'] = array(
     '#markup' => l(t('Add range'), "admin/islandora/ip_embargo/ranges/add/$list_identifier"),
+  );
+  $form['list_tabs']['list_embargoes'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Embargoes'),
+    '#access' => user_access('control islandora ip embargoes'),
+  );
+  $form['list_tabs']['list_embargoes']['embargoes'] = array(
+    '#type' => 'tableselect',
+    '#header' => $embargo_header,
+    '#options' => $embargo_options,
+    '#attributes' => array(),
+    '#empty' => t("There are no embargoes"),
+  );
+  $form['list_tabs']['list_embargoes']['embargo_pager'] = array(
+    '#markup' => theme('pager'),
+  );
+  $form['list_tabs']['list_embargoes']['delete_embargo'] = array(
+    '#type' => 'submit',
+    '#value' => t('Delete embargos'),
+    '#submit' => array('islandora_ip_embargo_edit_list_form_embargo_submit'),
   );
   return $form;
 }
@@ -240,6 +290,23 @@ function islandora_ip_embargo_edit_list_form_range_submit($form, &$form_state) {
   foreach ($form_state['values']['ranges'] as $range_identifier => $is_checked) {
     if ($is_checked) {
       islandora_ip_embargo_remove_range($range_identifier);
+    }
+  }
+}
+
+/**
+ * Delete an embargo from a list.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_ip_embargo_edit_list_form_embargo_submit($form, &$form_state) {
+  module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+  foreach ($form_state['values']['embargoes'] as $embargo_identifier => $is_checked) {
+    if ($is_checked) {
+      islandora_ip_embargo_remove_embargo($embargo_identifier);
     }
   }
 }
@@ -309,52 +376,91 @@ function islandora_ip_embargo_add_range_form_submit($form, &$form_state) {
  */
 function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandora_object) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
-  $form_state['storage']['islandroa_ip_embargo']['update'] = FALSE;
-  $form_state['storage']['islandroa_ip_embargo']['pid'] = $islandora_object->id;
+  $form_state['storage']['islandora_ip_embargo']['update'] = FALSE;
+  $form_state['storage']['islandora_ip_embargo']['pid'] = $islandora_object->id;
   $list_results = islandora_ip_embargo_get_lists();
-  $options = array('none' => NULL);
+  $options = array();
   while ($data = $list_results->fetchObject()) {
     $options[$data->lid] = $data->name;
   }
 
-  $form['lists'] = array(
-    '#type' => 'select',
-    '#title' => 'IP address range list',
-    '#description' => t('The list of IP ranges to limit access to this object to.'),
-    '#options' => $options,
-  );
-  $form['expiry_date'] = array(
-    '#type' => 'date',
-    '#title' => 'Expiry',
-    '#description' => t('When the Embargo will end.'),
-  );
-  $form['never_expire'] = array(
-    '#type' => 'checkbox',
-    '#title' => 'Never expire',
-    '#description' => t('This embargo should never expire, overrides the Expiry date field.'),
-  );
-
-  $embargo_result = islandora_ip_embargo_get_embargo($islandora_object->id);
-  if ($embargo_result->rowCount()) {
+  if (empty($options)) {
+    $form['empty'] = array(
+      '#markup' => '<p>There are currently no IP address range lists defined. At least one IP address range list must be defined in order to create an IP embargo on this object.</p>',
+    );
+  }
+  else {
+    $embargo_result = islandora_ip_embargo_get_embargo($islandora_object->id);
     $embargo_info = $embargo_result->fetchObject();
-    $form_state['storage']['islandroa_ip_embargo']['update'] = TRUE;
-    $form['lists']['#default_value'] = $embargo_info->lid;
-    if (!isset($embargo_info->expiry)) {
-      $form['never_expire']['#default_value'] = 1;
+    if ($embargo_result->rowCount()) {
+      if (!isset($embargo_info->expiry)) {
+        $embargo_message = t('This object is currently embargoed indefinitely.');
+        $form['current_embargo'] = array(
+          '#markup' => '<p>' . $embargo_message . '</p><hr/>',
+        );
+      }
+      else {
+        $year = date('Y', $embargo_info->expiry);
+        $month = date('F', $embargo_info->expiry);
+        $day = date('j', $embargo_info->expiry);
+        $ordinal = date('S', $embargo_info->expiry);
+        $embargo_message = t("This object's embargo is set to expire on the @day@ordinal of @month, @year.", array(
+          '@day' => $day,
+          '@month' => $month,
+          '@year' => $year,
+          '@ordinal' => $ordinal,
+        ));
+        $form['current_embargo_expiry'] = array(
+          '#markup' => '<p>' . $embargo_message . '</p><hr/>',
+        );
+      }
     }
-    else {
-      $year = date('Y', $embargo_info->expiry);
-      $month = date('n', $embargo_info->expiry);
-      $day = date('j', $embargo_info->expiry);
-      $form['expiry_date']['#default_value'] = array(
-        'year' => $year,
-        'month' => $month,
-        'day' => $day,
+    $form['lists'] = array(
+      '#type' => 'select',
+      '#title' => 'IP address range list',
+      '#description' => t('The list of IP ranges to limit access to this object to.'),
+      '#options' => $options,
+    );
+    $form['expiry_date'] = array(
+      '#type' => 'date',
+      '#title' => 'Expiry',
+      '#description' => t('When the Embargo will end.'),
+    );
+    $form['never_expire'] = array(
+      '#type' => 'checkbox',
+      '#title' => 'Never expire',
+      '#description' => t('This embargo should never expire, overrides the Expiry date field.'),
+    );
+
+    if ($embargo_result->rowCount()) {
+      $form_state['storage']['islandora_ip_embargo']['update'] = TRUE;
+      $form['lists']['#default_value'] = $embargo_info->lid;
+      if (!isset($embargo_info->expiry)) {
+        $form['never_expire']['#default_value'] = 1;
+      }
+      else {
+        $year = date('Y', $embargo_info->expiry);
+        $month = date('n', $embargo_info->expiry);
+        $day = date('j', $embargo_info->expiry);
+        $form['expiry_date']['#default_value'] = array(
+          'year' => $year,
+          'month' => $month,
+          'day' => $day,
+        );
+      }
+    }
+
+    $form['submit'] = array('#type' => 'submit', '#value' => t('Set Embargo'));
+
+    if ($embargo_result->rowCount()) {
+      $form['delete'] = array(
+        '#type' => 'submit',
+        '#value' => 'Clear Embargo',
+        '#submit' => array('islandora_ip_embargo_object_embargo_form_delete'),
+        '#limit_validation_errors' => array(),
       );
     }
   }
-
-  $form['submit'] = array('#type' => 'submit', '#value' => t('Set Embargo'));
 
   return $form;
 }
@@ -380,24 +486,35 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
       $form_state['values']['expiry_date']['year']
     );
   }
-  if ($form_state['storage']['islandroa_ip_embargo']['update']) {
+  if ($form_state['storage']['islandora_ip_embargo']['update']) {
     if ($form_state['values']['lists'] != 'none') {
       islandora_ip_embargo_update_embargo(
-        $form_state['storage']['islandroa_ip_embargo']['pid'],
+        $form_state['storage']['islandora_ip_embargo']['pid'],
         $form_state['values']['lists'],
         $expiry
       );
     }
-    else {
-      islandora_ip_embargo_remove_embargo($form_state['storage']['islandroa_ip_embargo']['pid']);
-    }
   }
   else {
     islandora_ip_embargo_set_embargo(
-      $form_state['storage']['islandroa_ip_embargo']['pid'],
+      $form_state['storage']['islandora_ip_embargo']['pid'],
       $form_state['values']['lists'],
       $expiry
     );
   }
+  return $form;
+}
+
+/**
+ * Submit handler for object embargo deletion.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_ip_embargo_object_embargo_form_delete($form, &$form_state) {
+  module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+  islandora_ip_embargo_remove_embargo($form_state['storage']['islandora_ip_embargo']['pid'], $is_pid = TRUE);
   return $form;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -218,6 +218,10 @@ function islandora_ip_embargo_set_embargo($islandora_object_id, $list_id, $expir
  *
  * @param string $embargo_identifier
  *   The UID of the object to remove the embargo from.
+ * @param bool $is_pid
+ *   Boolean defining whether the $embargo_identifier is an object PID.
+ *
+ *   If set to FALSE, $embargo_identifier will be treated as an EID.
  */
 function islandora_ip_embargo_remove_embargo($embargo_identifier, $is_pid = FALSE) {
   if (!$is_pid) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -216,13 +216,20 @@ function islandora_ip_embargo_set_embargo($islandora_object_id, $list_id, $expir
 /**
  * Remove an object's embargo information.
  *
- * @param string $islandora_object_id
- *   The PID of the object to remove the embargo from.
+ * @param string $embargo_identifier
+ *   The UID of the object to remove the embargo from.
  */
-function islandora_ip_embargo_remove_embargo($islandora_object_id) {
-  db_delete('islandora_ip_embargo_embargoes')
-  ->condition('pid', $islandora_object_id)
-  ->execute();
+function islandora_ip_embargo_remove_embargo($embargo_identifier, $is_pid = FALSE) {
+  if (!$is_pid) {
+    db_delete('islandora_ip_embargo_embargoes')
+    ->condition('eid', $embargo_identifier)
+    ->execute();
+  }
+  else {
+    db_delete('islandora_ip_embargo_embargoes')
+    ->condition('pid', $embargo_identifier)
+    ->execute();
+  }
 }
 
 /**

--- a/islandora_ip_embargo.info
+++ b/islandora_ip_embargo.info
@@ -4,5 +4,4 @@ package = Islandora
 dependencies[] = islandora
 version = 7.x-dev
 core = 7.x
-files[] = tests/islandora_ip_embargo_usage_test.test
 

--- a/islandora_ip_embargo.info
+++ b/islandora_ip_embargo.info
@@ -4,3 +4,5 @@ package = Islandora
 dependencies[] = islandora
 version = 7.x-dev
 core = 7.x
+files[] = tests/islandora_ip_embargo_usage_test.test
+

--- a/islandora_ip_embargo.install
+++ b/islandora_ip_embargo.install
@@ -67,6 +67,12 @@ function islandora_ip_embargo_schema() {
   $schema['islandora_ip_embargo_embargoes'] = array(
     'description' => 'Table that stores information on embargoed objects.',
     'fields' => array(
+      'eid' => array(
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'description' => 'The UID of the embargo',
+      ),
       'pid' => array(
         'type' => 'varchar',
         'length' => 255,
@@ -91,7 +97,7 @@ function islandora_ip_embargo_schema() {
         'columns' => array('lid' => 'lid'),
       ),
     ),
-    'primary key' => array('pid'),
+    'primary key' => array('eid'),
   );
 
   return $schema;


### PR DESCRIPTION
This update does a few things to the UI to facilitate ease of use:
- The IP Embargo tab on an object now replaces its form with a message if no IP range lists are defined, preventing users from attempting to add a NULL range list to an object.
- The IP Embargo tab also shows the current embargo status at-a-glance above the form, if an embargo exists; this may be more intuitive than looking at the form status for some users.
- The IP Embargo tab now uses a 'Delete Embargo' button as a more intuitive means of removing an IP embargo from an object.
- The management page for an individual range list is now split into vertical tabs, one for ranges and the other for embargoes. The latter is not visible without the 'control islandora ip embargoes' permission.
- The embargo list on an individual range's management page also includes links to each object's IP Embargo tab, giving users an easy way to manage the embargo if they have appropriate permissions to do so but cannot navigate to it because of an object embargo affecting that user.
