### PR TITLE
Islandora 957 Embargoed Object Thumbnail display

### DIFF
--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -141,8 +141,8 @@ function islandora_ip_embargo_islandora_object_access($op, $islandora_object, $u
   if (islandora_ip_embargo_restrict_access($islandora_object->id) && !user_access(ISLANDORA_IP_EMBARGO_MANAGE_EMBARGOES)) {
     // If there is a redirect configured then use it. If not let Drupal do it.
     $redirect_url = variable_get('islandora_ip_embargo_embargoed_redirect', '');
-    if ($redirect_url) {
-      if (strpos(current_path(), "islandora/object/{$islandora_object->id}") !== FALSE && strpos(current_path(), '/datastream/TN') === FALSE) {
+    if (strpos(current_path(), "islandora/object/{$islandora_object->id}") !== FALSE && strpos(current_path(), '/datastream/TN') === FALSE) {
+      if ($redirect_url) {
         drupal_goto($redirect_url);
       }
       else {
@@ -150,7 +150,7 @@ function islandora_ip_embargo_islandora_object_access($op, $islandora_object, $u
       }
     }
     else {
-      return FALSE;
+      return TRUE;
     }
   }
 

--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -139,9 +139,10 @@ function islandora_ip_embargo_islandora_object_access($op, $islandora_object, $u
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   // Handle an embargo.
   if (islandora_ip_embargo_restrict_access($islandora_object->id) && !user_access(ISLANDORA_IP_EMBARGO_MANAGE_EMBARGOES)) {
-    // If there is a redirect configured then use it. If not let Drupal do it.
-    $redirect_url = variable_get('islandora_ip_embargo_embargoed_redirect', '');
+  // If it is not a request for a thumbnail, don't let it through
     if (strpos(current_path(), "islandora/object/{$islandora_object->id}") !== FALSE && strpos(current_path(), '/datastream/TN') === FALSE) {
+  // If there is a redirect configured then use it. If not let Drupal do it.
+      $redirect_url = variable_get('islandora_ip_embargo_embargoed_redirect', '');
       if ($redirect_url) {
         drupal_goto($redirect_url);
       }
@@ -149,6 +150,7 @@ function islandora_ip_embargo_islandora_object_access($op, $islandora_object, $u
         return FALSE;
       }
     }
+  // If it is a thumbnail, let it through
     else {
       return TRUE;
     }


### PR DESCRIPTION
Relates to the issues described in https://jira.duraspace.org/browse/ISLANDORA-957
This fixes two problems with the logic in handling display of thumbnails for embargoed objects.

It now sets the function to return true when the object is a thumbnail, which is the required return value to allow an object to display.

It also allows thumbnails of embargoed objects to be displayed when the islandora_ip_embargo_embargoed_redirect variable is not set or is empty.
