### PR TITLE
ISLANDORA-1740 add custom text for islandora_ip_embargo module

### DIFF
--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -54,13 +54,13 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
   $form['islandora_ip_embargo_overlay_text_color'] = array(
     '#type' => 'textfield',
     '#title' => t('Embargoed item overlay text color'),
-    '#description' => t('Overlay text color in hexideciamal format (E.g. #FF0000).'),
-    '#maxlength' => 7,
+    '#description' => t('Overlay text color in hexideciamal format (E.g. FF0000).'),
+    '#maxlength' => 6,
     '#required' => TRUE,
     '#element_validate' => array('islandora_ip_embargo_hex_validate'),
     '#default_value' => variable_get(
       'islandora_ip_embargo_overlay_text_color',
-      '#FF0000'
+      'FF0000'
     ),
   );
 
@@ -550,7 +550,7 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
  */
 function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
   $color = $element['#value'];
-  if (!color_valid_hexadecimal_string($color)) {
-    form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexideciamal format, requires # followed by A-F and 0-9 characters only (E.g. #ABC987).'));
+  if (!ctype_xdigit($color) && strlen($color) === 6) {
+    form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexideciamal format, requires 6 characters and A-F 0-9 characters apply (E.g. F0A3B1).'));
   }
 }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -54,7 +54,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
   $form['islandora_ip_embargo_overlay_text_color'] = array(
     '#type' => 'textfield',
     '#title' => t('Embargoed item overlay text color'),
-    '#description' => t('Overlay text color in hexideciamal format (E.g. FF0000).'),
+    '#description' => t('Overlay text color in hexideciamal format (E.g. FF0000 or F0A).'),
     '#maxlength' => 6,
     '#required' => TRUE,
     '#element_validate' => array('islandora_ip_embargo_hex_validate'),
@@ -550,7 +550,7 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
  */
 function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
   $color = $element['#value'];
-  if (!ctype_xdigit($color) && strlen($color) === 6) {
-    form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexideciamal format, requires 6 characters and A-F 0-9 characters apply (E.g. F0A3B1).'));
+  if (!(ctype_xdigit($color) && (strlen($color) === 6 || strlen($color) === 3))) {
+    form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexideciamal format, requires 3 or 6 characters and A-F 0-9 characters apply (E.g. F0A3B1 or F1A).'));
   }
 }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -44,7 +44,8 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
   $form['islandora_ip_embargo_overlay_text'] = array(
     '#type' => 'textfield',
     '#title' => t('Embargoed item overlay text'),
-    '#description' => t('Value for overlay text on embargoed items.'),
+    '#description' => t('Overlay text on embargoed items.'),
+    '#required' => TRUE,
     '#default_value' => variable_get(
       'islandora_ip_embargo_overlay_text',
       'EMBARGOED'
@@ -53,20 +54,17 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
   $form['islandora_ip_embargo_overlay_text_color'] = array(
     '#type' => 'textfield',
     '#title' => t('Embargoed item overlay text color'),
-    '#description' => t('Value for overlay text color in hexideciamal format (E.g. FF0000).'),
-    '#maxlength' => 6,
+    '#description' => t('Overlay text color in hexideciamal format (E.g. #FF0000).'),
+    '#maxlength' => 7,
+    '#required' => TRUE,
+    '#element_validate' => array('islandora_ip_embargo_hex_validate'),
     '#default_value' => variable_get(
       'islandora_ip_embargo_overlay_text_color',
-      'FF0000'
+      '#FF0000'
     ),
   );
-  $form['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Save configuration'),
-    '#submit' => array('islandora_ip_embargo_settings_submit'),
-  );
 
-  return $form;
+  return system_settings_form($form);
 }
 
 /**
@@ -124,42 +122,6 @@ function islandora_ip_embargo_manage_embargo_list_form($form, &$form_state) {
   );
 
   return $form;
-}
-
-/**
- * Validate settings input.
- *
- * @param array $form
- *   The Drupal form definition.
- * @param array $form_state
- *   The Drupal form state.
- */
-function islandora_ip_embargo_settings_form_validate($form, &$form_state) {
-  $text = trim($form_state['values']['islandora_ip_embargo_overlay_text']);
-  $color = $form_state['values']['islandora_ip_embargo_overlay_text_color'];
-  if (empty($text)) {
-    form_set_error('islandora_ip_embargo_overlay_text', t('Overlay text field cannot be empty.'));
-  }
-  if (!preg_match('/([a-f]|[A-F]|[0-9]){6}(([a-f]|[A-F]|[0-9]){3})?\b/', $color)) {
-    form_set_error('islandora_ip_embargo_overlay_text_color', t('Overlay text color must match hexideciamal format, there must be 6 characters and only A-F and 0-9 are accepted (E.g. ABC987).'));
-  }
-}
-
-/**
- * Set variables and confirm submit success.
- *
- * @param array $form
- *   The Drupal form definition.
- * @param array $form_state
- *   The Drupal form state.
- */
-function islandora_ip_embargo_settings_submit($form, &$form_state) {
-  variable_set('islandora_ip_embargo_embargoed_redirect', $form_state['values']['islandora_ip_embargo_embargoed_redirect']);
-  variable_set('islandora_ip_embargo_embargoed_redirect_append_url', $form_state['values']['islandora_ip_embargo_embargoed_redirect_append_url']);
-  variable_set('islandora_ip_embargo_days_before_embargo_trigger', $form_state['values']['islandora_ip_embargo_days_before_embargo_trigger']);
-  variable_set('islandora_ip_embargo_overlay_text', trim($form_state['values']['islandora_ip_embargo_overlay_text']));
-  variable_set('islandora_ip_embargo_overlay_text_color', strtoupper($form_state['values']['islandora_ip_embargo_overlay_text_color']));
-  drupal_set_message(t('The configuration options have been saved.'));
 }
 
 /**
@@ -574,4 +536,21 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
     );
   }
   return $form;
+}
+
+/**
+ * Validate hexidecimal color input.
+ *
+ * @param array $element
+ *   The Drupal element data.
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
+  $color = $element['#value'];
+  if (!color_valid_hexadecimal_string($color)) {
+    form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexideciamal format, requires # followed by A-F and 0-9 characters only (E.g. #ABC987).'));
+  }
 }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -41,8 +41,32 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
       0
     ),
   );
+  $form['islandora_ip_embargo_overlay_text'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Embargoed item overlay text'),
+    '#description' => t('Value for overlay text on embargoed items.'),
+    '#default_value' => variable_get(
+      'islandora_ip_embargo_overlay_text',
+      'EMBARGOED'
+    ),
+  );
+  $form['islandora_ip_embargo_overlay_text_color'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Embargoed item overlay text color'),
+    '#description' => t('Value for overlay text color in hexideciamal format (E.g. FF0000).'),
+    '#maxlength' => 6,
+    '#default_value' => variable_get(
+      'islandora_ip_embargo_overlay_text_color',
+      'FF0000'
+    ),
+  );
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save configuration'),
+    '#submit' => array('islandora_ip_embargo_settings_submit'),
+  );
 
-  return system_settings_form($form);
+  return $form;
 }
 
 /**
@@ -100,6 +124,42 @@ function islandora_ip_embargo_manage_embargo_list_form($form, &$form_state) {
   );
 
   return $form;
+}
+
+/**
+ * Validate settings input.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_ip_embargo_settings_form_validate($form, &$form_state) {
+  $text = trim($form_state['values']['islandora_ip_embargo_overlay_text']);
+  $color = $form_state['values']['islandora_ip_embargo_overlay_text_color'];
+  if (empty($text)) {
+    form_set_error('islandora_ip_embargo_overlay_text', t('Overlay text field cannot be empty.'));
+  }
+  if (!preg_match('/([a-f]|[A-F]|[0-9]){6}(([a-f]|[A-F]|[0-9]){3})?\b/', $color)) {
+    form_set_error('islandora_ip_embargo_overlay_text_color', t('Overlay text color must match hexideciamal format, there must be 6 characters and only A-F and 0-9 are accepted (E.g. ABC987).'));
+  }
+}
+
+/**
+ * Set variables and confirm submit success.
+ *
+ * @param array $form
+ *   The Drupal form definition.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_ip_embargo_settings_submit($form, &$form_state) {
+  variable_set('islandora_ip_embargo_embargoed_redirect', $form_state['values']['islandora_ip_embargo_embargoed_redirect']);
+  variable_set('islandora_ip_embargo_embargoed_redirect_append_url', $form_state['values']['islandora_ip_embargo_embargoed_redirect_append_url']);
+  variable_set('islandora_ip_embargo_days_before_embargo_trigger', $form_state['values']['islandora_ip_embargo_days_before_embargo_trigger']);
+  variable_set('islandora_ip_embargo_overlay_text', trim($form_state['values']['islandora_ip_embargo_overlay_text']));
+  variable_set('islandora_ip_embargo_overlay_text_color', strtoupper($form_state['values']['islandora_ip_embargo_overlay_text_color']));
+  drupal_set_message(t('The configuration options have been saved.'));
 }
 
 /**

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -543,10 +543,10 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
  *
  * @param array $element
  *   The Drupal element data.
- * @param array $form
- *   The Drupal form definition.
  * @param array $form_state
  *   The Drupal form state.
+ * @param array $form
+ *   The Drupal form definition.
  */
 function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
   $color = $element['#value'];

--- a/islandora_ip_embargo.install
+++ b/islandora_ip_embargo.install
@@ -111,6 +111,8 @@ function islandora_ip_embargo_uninstall() {
   $drupal_variables = array(
     'islandora_ip_embargo_embargoed_redirect',
     'islandora_ip_embargo_days_before_embargo_trigger',
+    'islandora_ip_embargo_overlay_text',
+    'islandora_ip_embargo_overlay_text_color',
   );
   foreach ($drupal_variables as $drupal_variable) {
     variable_del($drupal_variable);

--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -195,7 +195,7 @@ function islandora_ip_embargo_preprocess_image(&$variables) {
   $image_path_parts = explode('/', $image_path);
   $size_of_image_path = count($image_path_parts);
   $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
-  $color = '#' . variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
+  $color = variable_get('islandora_ip_embargo_overlay_text_color', '#FF0000');
 
   if ($image_path_parts[$size_of_image_path - 1] == 'view' &&
       $image_path_parts[$size_of_image_path - 2] == 'TN' &&
@@ -206,8 +206,7 @@ function islandora_ip_embargo_preprocess_image(&$variables) {
 
     if ($embargo_result->rowCount()) {
       drupal_add_js(drupal_get_path('module', 'islandora_ip_embargo') . '/js/embargoed_images.js');
-      drupal_add_js(array('islandora_ip_embargo' => array('text' => $text)), array('type' => 'setting'));
-      drupal_add_js(array('islandora_ip_embargo' => array('color' => $color)), array('type' => 'setting'));
+      drupal_add_js(array('islandora_ip_embargo' => array('text' => $text, 'color' => $color)), array('type' => 'setting'));
       if (isset($variables['#attributes']['class'])) {
         $variables['attributes']['class'] = $variables['#attributes']['class']
           . 'islandora_ip_embargo_embargoed';

--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -194,6 +194,8 @@ function islandora_ip_embargo_preprocess_image(&$variables) {
   $image_path = parse_url($variables['path'], PHP_URL_PATH);
   $image_path_parts = explode('/', $image_path);
   $size_of_image_path = count($image_path_parts);
+  $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
+  $color = '#' . variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
 
   if ($image_path_parts[$size_of_image_path - 1] == 'view' &&
       $image_path_parts[$size_of_image_path - 2] == 'TN' &&
@@ -203,8 +205,9 @@ function islandora_ip_embargo_preprocess_image(&$variables) {
     $embargo_result = islandora_ip_embargo_get_embargo($pid);
 
     if ($embargo_result->rowCount()) {
-      drupal_add_js(drupal_get_path('module', 'islandora_ip_embargo')
-        . '/js/embargoed_images.js');
+      drupal_add_js(drupal_get_path('module', 'islandora_ip_embargo') . '/js/embargoed_images.js');
+      drupal_add_js(array('islandora_ip_embargo' => array('text' => $text)), array('type' => 'setting'));
+      drupal_add_js(array('islandora_ip_embargo' => array('color' => $color)), array('type' => 'setting'));
       if (isset($variables['#attributes']['class'])) {
         $variables['attributes']['class'] = $variables['#attributes']['class']
           . 'islandora_ip_embargo_embargoed';

--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -195,7 +195,7 @@ function islandora_ip_embargo_preprocess_image(&$variables) {
   $image_path_parts = explode('/', $image_path);
   $size_of_image_path = count($image_path_parts);
   $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
-  $color = variable_get('islandora_ip_embargo_overlay_text_color', '#FF0000');
+  $color = variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
 
   if ($image_path_parts[$size_of_image_path - 1] == 'view' &&
       $image_path_parts[$size_of_image_path - 2] == 'TN' &&

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -10,10 +10,10 @@ Drupal.behaviors.islandora_ip_embargo = {
       $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
       $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
       $('span.islandora_ip_embargo_embargoed').css({
-        'color' : Drupal.t(Drupal.settings.islandora_ip_embargo.color),
+        'color' : Drupal.settings.islandora_ip_embargo.color,
         'left' : '0',
         'padding' : '0.5em',
-        'font-size' : '1.5em',
+        'font-size' : '1.25em',
         'position' : 'absolute',
         'text-decoration' : 'none',
       });

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -1,6 +1,22 @@
-// Make embargoed thumbnails obvious.
-jQuery(document).ready(function($) {
-  $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
-  $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed" style="position:absolute;' +
-    'left:0em;text-decoration:none;color:red;font-size:1.5em">EMBARGOED</span>');
-});
+/**
+ * @file
+ * Show the overlay text for embargoed items.
+ */
+(function ($, Drupal, window, document, undefined) {
+Drupal.behaviors.islandora_ip_embargo = {
+  attach: function(context, settings) {
+    jQuery(document).ready(function($) {
+      $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
+      $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
+      $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
+      $('span.islandora_ip_embargo_embargoed').css({
+        'color' : Drupal.t(Drupal.settings.islandora_ip_embargo.color),
+        'left' : '0',
+        'padding' : '0.5em',
+        'font-size' : '1.5em',
+        'position' : 'absolute',
+        'text-decoration' : 'none',
+      });
+    });
+  }};
+})(jQuery, Drupal, this, this.document);

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -10,7 +10,7 @@ Drupal.behaviors.islandora_ip_embargo = {
       $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
       $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
       $('span.islandora_ip_embargo_embargoed').css({
-        'color' : Drupal.settings.islandora_ip_embargo.color,
+        'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
         'left' : '0',
         'padding' : '0.5em',
         'font-size' : '1.25em',


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1740
# What does this Pull Request do?

Added custom text and color textfields for embargoed item's overlay text.
# How should this be tested?
- In the settings UI (/admin/islandora/tools/ip_embargo/misc) supply a value for text and text color and submit.
- Embargo an object with a thumbnail datastream.
- Check to see if overlay text has been updated to supplied values.

---

Brandon Morrissey
_Junior Application Analyst_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
