### PR TITLE
ISLANDORA-1869

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 php:
   - 5.3.3
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 branches:
   only:
     - 7.x


### PR DESCRIPTION
**JIRA Ticket**: 

https://jira.duraspace.org/browse/ISLANDORA-1869

# What does this Pull Request do?

Adds three new PHP targets for Travis:
* 5.6
* 7.0
* 7.1

# What's new?

Drupal 7 mostly is support PHP 7
https://www.drupal.org/node/2656548
and Ubuntu 16.04 comes with PHP 7 so if we can we should see if Islandora will pass tests with against these new versions of PHP. 

# Additional Notes:

This should get discussed before it is merged, I just wanted to make pull requests against the core modules to see what passes and what fails.

# Interested parties
@Islandora/7-x-1-x-committers