### PR TITLE
Drush Functionality

### DIFF
--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -278,7 +278,7 @@ function islandora_ip_embargo_add_list_form_submit($form, &$form_state) {
 function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifier) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   $list_information = islandora_ip_embargo_get_lists_information($list_identifier);
-  $list_name = islandora_ip_embargo_get_list_object($list_identifier)->name;
+  $list_name = islandora_ip_embargo_get_list_object_by('lid', $list_identifier)->name;
   $form_state['storage']['islandora_ip_embargo']['list_identifier'] = $list_identifier;
 
   $header = array('low_end' => t('low end'), 'high_end' => t('high end'));

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -63,6 +63,18 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
       'FF0000'
     ),
   );
+  $form['islandora_ip_embargo_djatoka_public_ip_address'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Djatoka public ip'),
+    '#description' => t('IP address from which djatoka makes requests.'),
+    '#maxlength' => 15,
+    '#required' => FALSE,
+    '#element_validate' => array('islandora_ip_embargo_hex_validate'),
+    '#default_value' => variable_get(
+      'islandora_ip_embargo_djatoka_public_ip_address',
+      '127.0.0.1'
+    ),
+  );
 
   return system_settings_form($form);
 }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -74,6 +74,14 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
       '127.0.0.1'
     ),
   );
+  $form['islandora_ip_embargo_roles_exempt'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Roles Exempt'),
+    '#description' => t('Roles for which embargoes never apply.'),
+    '#maxlength' => 255,
+    '#required' => FALSE,
+    '#default_value' => variable_get('islandora_ip_embargo_roles_exempt',''),
+  );
 
   return system_settings_form($form);
 }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -69,7 +69,6 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
     '#description' => t('IP address from which djatoka makes requests.'),
     '#maxlength' => 15,
     '#required' => FALSE,
-    '#element_validate' => array('islandora_ip_embargo_hex_validate'),
     '#default_value' => variable_get(
       'islandora_ip_embargo_djatoka_public_ip_address',
       '127.0.0.1'

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -278,7 +278,7 @@ function islandora_ip_embargo_add_list_form_submit($form, &$form_state) {
 function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifier) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   $list_information = islandora_ip_embargo_get_lists_information($list_identifier);
-  $list_name = islandora_ip_embargo_get_list_name($list_identifier);
+  $list_name = islandora_ip_embargo_get_list_object($list_identifier)->name;
   $form_state['storage']['islandora_ip_embargo']['list_identifier'] = $list_identifier;
 
   $header = array('low_end' => t('low end'), 'high_end' => t('high end'));

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * This file holds forms for islandora_ip_embargo
@@ -21,8 +22,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
     '#title' => t('Object embargoed redirect'),
     '#description' => t('The URL to go to when an object is embargoed.'),
     '#default_value' => variable_get(
-      'islandora_ip_embargo_embargoed_redirect',
-      ''
+        'islandora_ip_embargo_embargoed_redirect', ''
     ),
   );
   $form['islandora_ip_embargo_embargoed_redirect_append_url'] = array(
@@ -37,8 +37,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
     '#title' => t('Days before embargo alert'),
     '#description' => t('Rules will be triggered this number of days before an embargo is lifted.'),
     '#default_value' => variable_get(
-      'islandora_ip_embargo_days_before_embargo_trigger',
-      0
+        'islandora_ip_embargo_days_before_embargo_trigger', 0
     ),
   );
   $form['islandora_ip_embargo_overlay_text'] = array(
@@ -47,8 +46,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
     '#description' => t('Overlay text on embargoed items.'),
     '#required' => TRUE,
     '#default_value' => variable_get(
-      'islandora_ip_embargo_overlay_text',
-      'EMBARGOED'
+        'islandora_ip_embargo_overlay_text', 'EMBARGOED'
     ),
   );
   $form['islandora_ip_embargo_overlay_text_color'] = array(
@@ -59,8 +57,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
     '#required' => TRUE,
     '#element_validate' => array('islandora_ip_embargo_hex_validate'),
     '#default_value' => variable_get(
-      'islandora_ip_embargo_overlay_text_color',
-      'FF0000'
+        'islandora_ip_embargo_overlay_text_color', 'FF0000'
     ),
   );
   $form['islandora_ip_embargo_djatoka_public_ip_address'] = array(
@@ -70,8 +67,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
     '#maxlength' => 15,
     '#required' => FALSE,
     '#default_value' => variable_get(
-      'islandora_ip_embargo_djatoka_public_ip_address',
-      '127.0.0.1'
+        'islandora_ip_embargo_djatoka_public_ip_address', '127.0.0.1'
     ),
   );
   $form['islandora_ip_embargo_roles_exempt'] = array(
@@ -80,7 +76,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
     '#description' => t('Roles for which embargoes never apply.'),
     '#maxlength' => 255,
     '#required' => FALSE,
-    '#default_value' => variable_get('islandora_ip_embargo_roles_exempt',''),
+    '#default_value' => variable_get('islandora_ip_embargo_roles_exempt', ''),
   );
 
   return system_settings_form($form);
@@ -353,8 +349,7 @@ function islandora_ip_embargo_edit_list_form($form, &$form_state, $list_identifi
 function islandora_ip_embargo_edit_list_form_name_submit($form, &$form_state) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   islandora_ip_embargo_edit_list(
-    $form_state['values']['name'],
-    $form_state['storage']['islandora_ip_embargo']['list_identifier']);
+      $form_state['values']['name'], $form_state['storage']['islandora_ip_embargo']['list_identifier']);
 }
 
 /**
@@ -425,7 +420,7 @@ function islandora_ip_embargo_add_range_form_validate(array $form, array &$form_
     form_set_error('high_end', t('High end IP is not valid.'));
   }
 
-  if ($comparable_low !== FALSE && $comparable_high !== FALSE &&  $comparable_low > $comparable_high) {
+  if ($comparable_low !== FALSE && $comparable_high !== FALSE && $comparable_low > $comparable_high) {
     form_set_error('', t('IP range is not valid. The low address is greater than the high.'));
   }
 }
@@ -443,9 +438,7 @@ function islandora_ip_embargo_add_range_form_submit($form, &$form_state) {
   $list_identifier = $form_state['storage']['islandora_ip_embargo']['list_identifier'];
 
   islandora_ip_embargo_add_ip_range(
-    $list_identifier,
-    $form_state['values']['low_end'],
-    $form_state['values']['high_end']
+      $list_identifier, $form_state['values']['low_end'], $form_state['values']['high_end']
   );
 
   $form_state['redirect'] = "admin/islandora/tools/ip_embargo/lists/$list_identifier";
@@ -527,20 +520,13 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
   $expiry = NULL;
   if (!$form_state['values']['never_expire']) {
     $expiry = mktime(
-      0,
-      0,
-      0,
-      $form_state['values']['expiry_date']['month'],
-      $form_state['values']['expiry_date']['day'],
-      $form_state['values']['expiry_date']['year']
+        0, 0, 0, $form_state['values']['expiry_date']['month'], $form_state['values']['expiry_date']['day'], $form_state['values']['expiry_date']['year']
     );
   }
   if ($form_state['storage']['islandroa_ip_embargo']['update']) {
     if ($form_state['values']['lists'] != 'none') {
       islandora_ip_embargo_update_embargo(
-        $form_state['storage']['islandroa_ip_embargo']['pid'],
-        $form_state['values']['lists'],
-        $expiry
+          $form_state['storage']['islandroa_ip_embargo']['pid'], $form_state['values']['lists'], $expiry
       );
     }
     else {
@@ -549,9 +535,7 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
   }
   else {
     islandora_ip_embargo_set_embargo(
-      $form_state['storage']['islandroa_ip_embargo']['pid'],
-      $form_state['values']['lists'],
-      $expiry
+        $form_state['storage']['islandroa_ip_embargo']['pid'], $form_state['values']['lists'], $expiry
     );
   }
   return $form;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -70,33 +70,30 @@ function islandora_ip_embargo_remove_list($list_identifier) {
 }
 
 /**
- * Get the name of a list.
+ * Get the a list object.
  *
- * @param int $list_identifier
- *   The identifier of the list to delete.
+ * @param string $field
+ *   Field in islandora_ip_embargo_lists to use for the lookup.
+ *   Must be one of 'lid' | 'name'; or error.
+ * 
+ * @param string $value
+ *   Value of the field used for the lookup.
  *
  * @return object $data
  *   The list object.
- *   
+ * 
  */
-function islandora_ip_embargo_get_list_object($list_identifier) {
-  $list = db_select('islandora_ip_embargo_lists')
-  ->fields('islandora_ip_embargo_lists')
-  ->condition('lid', $list_identifier)
+function islandora_ip_embargo_get_list_object_by($field, $value) {
+  if(!in_array($field, array('lid', 'name'))){
+    throw new Exception("Incorrect field: ($field) given for list lookup");
+  }
+
+  $list = db_select('islandora_ip_embargo_lists', 'i')
+  ->fields("i")
+  ->condition($field, $value)
+  ->range(0,1)
   ->execute();
-  $data = $list->fetchObject();
-
-  return $data;
-}
-
-function islandora_ip_embargo_get_list_object_by_name($list_name) {
-  $list = db_select('islandora_ip_embargo_lists')
-  ->fields('islandora_ip_embargo_lists')
-  ->condition('name', $list_name)
-  ->execute();
-  $data = $list->fetchObject();
-
-  return $data;
+  return $list->fetchObject();
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -89,9 +89,8 @@ function islandora_ip_embargo_remove_list($list_identifier) {
  * @param string $value
  *   Value of the field used for the lookup.
  *
- * @return object $data
+ * @return object
  *   The list object.
- * 
  */
 function islandora_ip_embargo_get_list_object_by($field, $value) {
   if (!in_array($field, array('lid', 'name'))) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,7 +1,8 @@
 <?php
+
 /**
  * @file
- * Holds helper functions for islandora_ip_embargo.
+ * Helper functions for islandora_ip_embargo.
  */
 
 /**
@@ -22,11 +23,20 @@ function islandora_ip_embargo_get_lists() {
   return $query->execute();
 }
 
+/**
+ * Fetch range records for a given list.
+ * 
+ * @param int $lid
+ *   list id, PK for the table islandora_ip_embargo_ip_ranges
+ * 
+ * @return DatabaseStatementInterface
+ *   query result
+ */
 function islandora_ip_embargo_get_ranges($lid) {
-    $ranges = db_select('islandora_ip_embargo_ip_ranges')
-            ->fields('islandora_ip_embargo_ip_ranges')
-            ->condition('lid', $lid)
-            ->execute();
+  $ranges = db_select('islandora_ip_embargo_ip_ranges')
+      ->fields('islandora_ip_embargo_ip_ranges')
+      ->condition('lid', $lid)
+      ->execute();
   return $ranges;
 }
 
@@ -38,8 +48,8 @@ function islandora_ip_embargo_get_ranges($lid) {
  */
 function islandora_ip_embargo_add_list($name) {
   db_insert('islandora_ip_embargo_lists')
-  ->fields(array('name' => $name))
-  ->execute();
+      ->fields(array('name' => $name))
+      ->execute();
 }
 
 /**
@@ -52,9 +62,9 @@ function islandora_ip_embargo_add_list($name) {
  */
 function islandora_ip_embargo_edit_list($name, $list_identifier) {
   db_update('islandora_ip_embargo_lists')
-  ->fields(array('name' => $name))
-  ->condition('lid', $list_identifier)
-  ->execute();
+      ->fields(array('name' => $name))
+      ->condition('lid', $list_identifier)
+      ->execute();
 }
 
 /**
@@ -65,8 +75,8 @@ function islandora_ip_embargo_edit_list($name, $list_identifier) {
  */
 function islandora_ip_embargo_remove_list($list_identifier) {
   db_delete('islandora_ip_embargo_lists')
-  ->condition('lid', $list_identifier)
-  ->execute();
+      ->condition('lid', $list_identifier)
+      ->execute();
 }
 
 /**
@@ -89,10 +99,10 @@ function islandora_ip_embargo_get_list_object_by($field, $value) {
   }
 
   $list = db_select('islandora_ip_embargo_lists', 'i')
-  ->fields("i")
-  ->condition($field, $value)
-  ->range(0, 1)
-  ->execute();
+      ->fields("i")
+      ->condition($field, $value)
+      ->range(0, 1)
+      ->execute();
   return $list->fetchObject();
 }
 
@@ -129,8 +139,8 @@ function islandora_ip_embargo_get_lists_information($list_identifier, $page_resu
  */
 function islandora_ip_embargo_remove_range($range_identifier) {
   db_delete('islandora_ip_embargo_ip_ranges')
-  ->condition('rid', $range_identifier)
-  ->execute();
+      ->condition('rid', $range_identifier)
+      ->execute();
 }
 
 /**
@@ -145,12 +155,12 @@ function islandora_ip_embargo_remove_range($range_identifier) {
  */
 function islandora_ip_embargo_add_ip_range($list_identifier, $low_end, $high_end) {
   db_insert('islandora_ip_embargo_ip_ranges')
-  ->fields(array(
-    'low_end' => $low_end,
-    'high_end' => $high_end,
-    'lid' => $list_identifier,
-  ))
-  ->execute();
+      ->fields(array(
+        'low_end' => $low_end,
+        'high_end' => $high_end,
+        'lid' => $list_identifier,
+      ))
+      ->execute();
 }
 
 /**
@@ -164,9 +174,9 @@ function islandora_ip_embargo_add_ip_range($list_identifier, $low_end, $high_end
  */
 function islandora_ip_embargo_get_embargo($islandora_object_id) {
   $embargoes = db_select('islandora_ip_embargo_embargoes')
-  ->fields('islandora_ip_embargo_embargoes')
-  ->condition('pid', $islandora_object_id)
-  ->execute();
+      ->fields('islandora_ip_embargo_embargoes')
+      ->condition('pid', $islandora_object_id)
+      ->execute();
 
   return $embargoes;
 }
@@ -182,9 +192,9 @@ function islandora_ip_embargo_get_embargo($islandora_object_id) {
  */
 function islandora_ip_embargo_get_embargos($list_identifier) {
   $embargoes = db_select('islandora_ip_embargo_embargoes')
-  ->fields('islandora_ip_embargo_embargoes')
-  ->condition('lid', $list_identifier)
-  ->execute();
+      ->fields('islandora_ip_embargo_embargoes')
+      ->condition('lid', $list_identifier)
+      ->execute();
 
   return $embargoes;
 }
@@ -201,13 +211,13 @@ function islandora_ip_embargo_get_embargos($list_identifier) {
  */
 function islandora_ip_embargo_update_embargo($islandora_object_id, $list_id, $expiry = NULL) {
   db_update('islandora_ip_embargo_embargoes')
-  ->fields(array(
-    'pid' => $islandora_object_id,
-    'lid' => $list_id,
-    'expiry' => $expiry,
-  ))
-  ->condition('pid', $islandora_object_id)
-  ->execute();
+      ->fields(array(
+        'pid' => $islandora_object_id,
+        'lid' => $list_id,
+        'expiry' => $expiry,
+      ))
+      ->condition('pid', $islandora_object_id)
+      ->execute();
 }
 
 /**
@@ -222,12 +232,12 @@ function islandora_ip_embargo_update_embargo($islandora_object_id, $list_id, $ex
  */
 function islandora_ip_embargo_set_embargo($islandora_object_id, $list_id, $expiry = NULL) {
   db_insert('islandora_ip_embargo_embargoes')
-  ->fields(array(
-    'pid' => $islandora_object_id,
-    'lid' => $list_id,
-    'expiry' => $expiry,
-  ))
-  ->execute();
+      ->fields(array(
+        'pid' => $islandora_object_id,
+        'lid' => $list_id,
+        'expiry' => $expiry,
+      ))
+      ->execute();
 }
 
 /**
@@ -238,8 +248,8 @@ function islandora_ip_embargo_set_embargo($islandora_object_id, $list_id, $expir
  */
 function islandora_ip_embargo_remove_embargo($islandora_object_id) {
   db_delete('islandora_ip_embargo_embargoes')
-  ->condition('pid', $islandora_object_id)
-  ->execute();
+      ->condition('pid', $islandora_object_id)
+      ->execute();
 }
 
 /**
@@ -257,9 +267,9 @@ function islandora_ip_embargo_ip_in_range($low, $high) {
   if ($comparable_address >= $comparable_low && $comparable_address <= $comparable_high) {
     return TRUE;
   }
-  $djip = variable_get('islandora_ip_embargo_djatoka_public_ip_address','127.0.0.1');
-  if($comparable_address == ip2long($djip)){
-      return TRUE;
+  $djip = variable_get('islandora_ip_embargo_djatoka_public_ip_address', '127.0.0.1');
+  if ($comparable_address == ip2long($djip)) {
+    return TRUE;
   }
   return FALSE;
 }
@@ -272,13 +282,11 @@ function islandora_ip_embargo_ip_in_range($low, $high) {
  */
 function islandora_ip_embargo_cron_cleanup($time_stamp) {
   $num_deleted = db_delete('islandora_ip_embargo_embargoes')
-  ->condition('expiry', $time_stamp, '<=')
-  ->execute();
+      ->condition('expiry', $time_stamp, '<=')
+      ->execute();
 
   watchdog(
-    'Cron Job End',
-    "The ip embargo cron job has ended, @num_deleted embargos have been removed.",
-    array('@num_deleted' => $num_deleted)
+      'Cron Job End', "The ip embargo cron job has ended, @num_deleted embargos have been removed.", array('@num_deleted' => $num_deleted)
   );
 }
 
@@ -301,16 +309,16 @@ function islandora_ip_embargo_send_embargo_lift_events($days_before) {
           array($event_threshold)),
       ),
       'finished' => 'islandora_ip_embargo_lift_event_batch_finished',
-      'title' => t('Sending out embargo lift events.'),
-      'init_message' => t('Event batch starting.'),
-      'progress_message' => t('Processed @current out of @total.'),
-      'error_message' => t('Event batch has encountered an error.'),
+      'title' => TableSort('Sending out embargo lift events.'),
+      'init_message' => TableSort('Event batch starting.'),
+      'progress_message' => TableSort('Processed @current out of @total.'),
+      'error_message' => TableSort('Event batch has encountered an error.'),
       'file' => drupal_get_path('module', 'islandora_ip_embargo') . '/includes/batch.inc',
     ));
 
     // This is a hack around the broken batch API.
     // https://drupal.org/node/638712#comment-2289138
-    $batch =& batch_get();
+    $batch = & batch_get();
     $batch['progressive'] = FALSE;
 
     batch_process();
@@ -330,12 +338,12 @@ function islandora_ip_embargo_send_embargo_lift_events($days_before) {
  */
 function islandora_ip_embargo_count_embargoes_before_timestamp($event_threshold) {
   return db_select('islandora_ip_embargo_embargoes')
-  ->fields('islandora_ip_embargo_embargoes')
-  ->condition('expiry', $event_threshold, '<=')
-  ->condition('expiry_event_triggered', 0, '=')
-  ->countQuery()
-  ->execute()
-  ->fetchField();
+          ->fields('islandora_ip_embargo_embargoes')
+          ->condition('expiry', $event_threshold, '<=')
+          ->condition('expiry_event_triggered', 0, '=')
+          ->countQuery()
+          ->execute()
+          ->fetchField();
 }
 
 /**
@@ -355,12 +363,12 @@ function islandora_ip_embargo_count_embargoes_before_timestamp($event_threshold)
  */
 function islandora_ip_embargo_get_embargoes_before_timestamp($event_threshold, $offset, $limit) {
   return db_select('islandora_ip_embargo_embargoes')
-  ->fields('islandora_ip_embargo_embargoes')
-  ->condition('expiry', $event_threshold, '<=')
-  ->condition('expiry_event_triggered', 0, '=')
-  ->orderBy('pid', 'ASC')
-  ->range($offset, $limit)
-  ->execute();
+          ->fields('islandora_ip_embargo_embargoes')
+          ->condition('expiry', $event_threshold, '<=')
+          ->condition('expiry_event_triggered', 0, '=')
+          ->orderBy('pid', 'ASC')
+          ->range($offset, $limit)
+          ->execute();
 }
 
 /**
@@ -374,10 +382,10 @@ function islandora_ip_embargo_get_embargoes_before_timestamp($event_threshold, $
  */
 function islandora_ip_embargo_set_event_triggered($event_threshold) {
   return db_update('islandora_ip_embargo_embargoes')
-  ->fields(array('expiry_event_triggered' => 1))
-  ->condition('expiry', $event_threshold, '<=')
-  ->condition('expiry_event_triggered', 0, '=')
-  ->execute();
+          ->fields(array('expiry_event_triggered' => 1))
+          ->condition('expiry', $event_threshold, '<=')
+          ->condition('expiry_event_triggered', 0, '=')
+          ->execute();
 }
 
 /**
@@ -423,10 +431,10 @@ function islandora_ip_embargo_restrict_access($pid) {
         }
       }
       global $user;
-      $roles_exempt = explode(',',variable_get('islandora_ip_embargo_roles_exempt',''));
+      $roles_exempt = explode(',', variable_get('islandora_ip_embargo_roles_exempt', ''));
       $qualifying_roles = array_intersect($roles_exempt, $user->roles);
-      if(!empty($qualifying_roles)){
-          $open_access = TRUE;
+      if (!empty($qualifying_roles)) {
+        $open_access = TRUE;
       }
     }
     else {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -22,7 +22,7 @@ function islandora_ip_embargo_get_lists() {
   return $query->execute();
 }
 
-function islandora_ip_embargo_get_ranges($lid){
+function islandora_ip_embargo_get_ranges($lid) {
     $ranges = db_select('islandora_ip_embargo_ip_ranges')
             ->fields('islandora_ip_embargo_ip_ranges')
             ->condition('lid', $lid)
@@ -84,14 +84,14 @@ function islandora_ip_embargo_remove_list($list_identifier) {
  * 
  */
 function islandora_ip_embargo_get_list_object_by($field, $value) {
-  if(!in_array($field, array('lid', 'name'))){
+  if (!in_array($field, array('lid', 'name'))) {
     throw new Exception("Incorrect field: ($field) given for list lookup");
   }
 
   $list = db_select('islandora_ip_embargo_lists', 'i')
   ->fields("i")
   ->condition($field, $value)
-  ->range(0,1)
+  ->range(0, 1)
   ->execute();
   return $list->fetchObject();
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -422,6 +422,12 @@ function islandora_ip_embargo_restrict_access($pid) {
           $open_access = TRUE;
         }
       }
+      global $user;
+      $roles_exempt = explode(',',variable_get('islandora_ip_embargo_roles_exempt',''));
+      $qualifying_roles = array_intersect($roles_exempt, $user->roles);
+      if(!empty($qualifying_roles)){
+          $open_access = TRUE;
+      }
     }
     else {
       $open_access = TRUE;

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -17,9 +17,17 @@ function islandora_ip_embargo_get_lists() {
   $query = $query->fields('islandora_ip_embargo_lists');
   $query = $query->extend('TableSort');
   $query = $query->extend('PagerDefault');
-  $query = $query->limit(10);
+  $query = $query->limit(100);
 
   return $query->execute();
+}
+
+function islandora_ip_embargo_get_ranges($lid){
+    $ranges = db_select('islandora_ip_embargo_ip_ranges')
+            ->fields('islandora_ip_embargo_ip_ranges')
+            ->condition('lid', $lid)
+            ->execute();
+  return $ranges;
 }
 
 /**
@@ -67,17 +75,28 @@ function islandora_ip_embargo_remove_list($list_identifier) {
  * @param int $list_identifier
  *   The identifier of the list to delete.
  *
- * @return string
- *   The human readable name of the list.
+ * @return object $data
+ *   The list object.
+ *   
  */
-function islandora_ip_embargo_get_list_name($list_identifier) {
+function islandora_ip_embargo_get_list_object($list_identifier) {
   $list = db_select('islandora_ip_embargo_lists')
   ->fields('islandora_ip_embargo_lists')
   ->condition('lid', $list_identifier)
   ->execute();
   $data = $list->fetchObject();
 
-  return $data->name;
+  return $data;
+}
+
+function islandora_ip_embargo_get_list_object_by_name($list_name) {
+  $list = db_select('islandora_ip_embargo_lists')
+  ->fields('islandora_ip_embargo_lists')
+  ->condition('name', $list_name)
+  ->execute();
+  $data = $list->fetchObject();
+
+  return $data;
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -257,6 +257,10 @@ function islandora_ip_embargo_ip_in_range($low, $high) {
   if ($comparable_address >= $comparable_low && $comparable_address <= $comparable_high) {
     return TRUE;
   }
+  $djip = variable_get('islandora_ip_embargo_djatoka_public_ip_address','127.0.0.1');
+  if($comparable_address == ip2long($djip)){
+      return TRUE;
+  }
   return FALSE;
 }
 

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -148,20 +148,19 @@ function drush_islandora_ip_embargo_set_embargo_for_item(){
     }
     $exp_str = $expiry == NULL ? "Never" : $expiry;
 
-        // determine whether an embargo exists already for an object.
-        $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();
-        if($update){
-            if($update->lid == $list->lid && $update->expiry == $expiry){
-                drupal_set_message(t("No update required for IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-                return;
-            }
-            islandora_ip_embargo_update_embargo($pid, $list->lid, $expiry);
-            drupal_set_message(t("Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-            watchdog('islandora_ip_embargo', "Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
-        }else{
-            islandora_ip_embargo_set_embargo($pid, $list->lid, $expiry);
-            drupal_set_message(t("Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-            watchdog('islandora_ip_embargo', "Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+    // determine whether an embargo exists already for an object.
+    $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();
+    if($update){
+        if($update->lid == $list->lid && $update->expiry == $expiry){
+            drupal_set_message(t("No update required for IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+            return;
         }
+        islandora_ip_embargo_update_embargo($pid, $list->lid, $expiry);
+        drupal_set_message(t("Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+        watchdog('islandora_ip_embargo', "Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+    }else{
+        islandora_ip_embargo_set_embargo($pid, $list->lid, $expiry);
+        drupal_set_message(t("Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+        watchdog('islandora_ip_embargo', "Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
     }
 }

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -42,6 +42,29 @@ function islandora_ip_embargo_drush_command(){
         ),
         'aliases' => array('iipese'),
     );
+    $items['islandora-ip-embargo-set-embargo-from-pid-list'] = array(
+      'description' => dt('Create a collection container.'),
+      'examples' => array('drush islandora-utils-create-collection --parent=islandora:root --namespace=my:collection'),
+      'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+      'drupal dependencies' => array(
+        'islandora',
+        'islandora_ip_embargo', //include version dependency ?
+      ),
+      'options' => array(
+        'pidsfile'  => array(
+          'description' => dt('File containing a comma-separated string of pids'),
+          'required'    => FALSE
+        ),
+        'lists' => array(
+          'description' => dt('comma-separated names of network lists to set.'),
+          'required' => TRUE,
+        ),
+        'expiry' => array(
+          dt("When to expire the embargo."),
+          'required' => FALSE,
+        )
+      ),
+    );
     return $items;
 }
 
@@ -119,7 +142,25 @@ function drush_islandora_ip_embargo_set_embargo_for_item(){
         'list' => drush_get_option('list'),
         'expiry' => drush_get_option('expiry'),
     );
+    make_embargo_from_params($params);
+}
 
+function drush_islandora_ip_embargo_set_embargo_from_pid_list(){
+    $pids   = explode(',', drush_get_option('pidsfile'));
+    $expiry = drush_get_option('expiry');
+    $lists  = explode(',', drush_get_option('lists'));
+    $params = array('expiry' => $expiry);
+
+    foreach ($lists as $list){
+        foreach($pids as $pid){
+            $params['pid'] = $pid;
+            $params['list'] = $list;
+            make_embargo_from_params($params);
+        }
+    }
+}
+
+function make_embargo_from_params($params){
     $pid = $params['pid'];
     $list = islandora_ip_embargo_get_list_object_by('name', $params['list']);
 

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -91,7 +91,7 @@ function drush_islandora_ip_embargo_addRange(){
 function is_duplicate_range($lid, $low, $high){
     foreach(islandora_ip_embargo_get_ranges($lid) as $range){
         if($range->low_end == $low && $range->high_end == $high){
-            drush_set_error("Duplicate IP range.");
+            drupal_set_message(t("Duplicate IP range. Nothing changed."));
             return true;
         }
     }
@@ -144,10 +144,9 @@ function drush_islandora_ip_embargo_set_embargo_for_item(){
     // check for good pid.
     $object = islandora_object_load($pid);
     if(!$object){
-        drush_set_error("Object $pid does not exist in this repository.");
-        return;
-    }else{
-        $exp_str = $expiry == NULL ? "Never" : $expiry;
+        //drupal_set_message(t("Object %p does not exist in this repository.", array('%p' => $pid)));
+    }
+    $exp_str = $expiry == NULL ? "Never" : $expiry;
 
         // determine whether an embargo exists already for an object.
         $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -1,6 +1,6 @@
 <?php
 
-function islandora_ip_embargo_drush_command(){
+function islandora_ip_embargo_drush_command() {
     $items = array();
     $items['islandora-ip-embargo-addRange'] = array(
         'description' => 'Add a network address range to the embargo list.',
@@ -69,7 +69,7 @@ function islandora_ip_embargo_drush_command(){
 }
 
 
-function drush_islandora_ip_embargo_addRange(){
+function drush_islandora_ip_embargo_addRange() {
     module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
     $params = array(
         'low' => drush_get_option('low'),
@@ -80,9 +80,8 @@ function drush_islandora_ip_embargo_addRange(){
     $low  = $params['low'];
     $high = $params['high'];
     // check that input vars are valid IPs
-    foreach(array($low, $high) as $ip){
-        if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
-            //drupal_set_message(t("!!! %i is NOT a valid IP address", array('%i' => $ip)), 'error');
+    foreach (array($low, $high) as $ip) {
+        if (filter_var($ip, FILTER_VALIDATE_IP) === FALSE) {
             drush_set_error("Invalid IP: $ip");
             return;
         }
@@ -90,19 +89,19 @@ function drush_islandora_ip_embargo_addRange(){
 
     // set up lists vars
     $target_list = $params['list'];
-    $target_list_id = false;
+    $target_list_id = FALSE;
     $lists = islandora_ip_embargo_get_lists();
 
-    foreach($lists as $list){
-        if($target_list == $list->name){
+    foreach ($lists as $list) {
+        if ($target_list == $list->name) {
             $target_list_id = $list->lid;
-            if(is_duplicate_range($list->lid, $low, $high)){
+            if(is_duplicate_range($list->lid, $low, $high)) {
                 return;
             }
             break;
         }
     }
-    if(!$target_list_id){
+    if (!$target_list_id) {
         islandora_ip_embargo_add_list($target_list);
         $target_list_id = islandora_ip_embargo_get_list_object_by('name', $target_list)->lid;
         drupal_set_message(t('Created list %l', array('%l'=> $target_list)));
@@ -111,31 +110,31 @@ function drush_islandora_ip_embargo_addRange(){
     islandora_ip_embargo_add_ip_range($target_list_id, $low, $high);
 }
 
-function is_duplicate_range($lid, $low, $high){
-    foreach(islandora_ip_embargo_get_ranges($lid) as $range){
-        if($range->low_end == $low && $range->high_end == $high){
+function is_duplicate_range($lid, $low, $high) {
+    foreach (islandora_ip_embargo_get_ranges($lid) as $range) {
+        if ($range->low_end == $low && $range->high_end == $high) {
             drupal_set_message(t("Duplicate IP range. Nothing changed."));
-            return true;
+            return TRUE;
         }
     }
 }
 
 
-function drush_islandora_ip_embargo_list_lists(){
+function drush_islandora_ip_embargo_list_lists() {
     module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
 
     $lists = islandora_ip_embargo_get_lists();
     printf("Network lists\n==============\n");
-    foreach($lists as $list){
+    foreach ($lists as $list) {
         printf("%s\n", $list->name);
-        foreach(islandora_ip_embargo_get_ranges($list->lid) as $range){
+        foreach (islandora_ip_embargo_get_ranges($list->lid) as $range) {
             printf("%s - %s\n", $range->low_end, $range->high_end);
         }
         printf("\n");
     }
 }
 
-function drush_islandora_ip_embargo_set_embargo_for_item(){
+function drush_islandora_ip_embargo_set_embargo_for_item() {
     module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
     $params = array(
         'pid' => drush_get_option('pid'),
@@ -145,14 +144,14 @@ function drush_islandora_ip_embargo_set_embargo_for_item(){
     make_embargo_from_params($params);
 }
 
-function drush_islandora_ip_embargo_set_embargo_from_pid_list(){
+function drush_islandora_ip_embargo_set_embargo_from_pid_list() {
     $pids   = explode(',', file_get_contents(drush_get_option('pidsfile')));
     $expiry = drush_get_option('expiry');
     $lists  = explode(',', drush_get_option('lists'));
     $params = array('expiry' => $expiry);
 
-    foreach ($lists as $list){
-        foreach($pids as $pid){
+    foreach ($lists as $list) {
+        foreach ($pids as $pid) {
             $params['pid'] = $pid;
             $params['list'] = $list;
             make_embargo_from_params($params);
@@ -160,13 +159,13 @@ function drush_islandora_ip_embargo_set_embargo_from_pid_list(){
     }
 }
 
-function make_embargo_from_params($params){
+function make_embargo_from_params($params) {
     module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
     $pid = $params['pid'];
     $list = islandora_ip_embargo_get_list_object_by('name', $params['list']);
 
     // set up expiry date from params
-    if($params['expiry'] !== NULL){
+    if ($params['expiry'] !== NULL) {
         $date_elements = explode('-', $params['expiry']);
         if(count($date_elements) != 3){
             drush_set_error("Expiry argument expects the date given as YYYY-MM-DD. Got $date_elements");
@@ -185,22 +184,22 @@ function make_embargo_from_params($params){
 
     // check for good pid.
     $object = islandora_object_load($pid);
-    if(!$object){
+    if (!$object) {
         //drupal_set_message(t("Object %p does not exist in this repository.", array('%p' => $pid)));
     }
     $exp_str = $expiry == NULL ? "Never" : $expiry;
 
     // determine whether an embargo exists already for an object.
     $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();
-    if($update){
-        if($update->lid == $list->lid && $update->expiry == $expiry){
+    if ($update) {
+        if ($update->lid == $list->lid && $update->expiry == $expiry) {
             drupal_set_message(t("No update required for IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
             return;
         }
         islandora_ip_embargo_update_embargo($pid, $list->lid, $expiry);
         drupal_set_message(t("Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
         watchdog('islandora_ip_embargo', "Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
-    }else{
+    } else {
         islandora_ip_embargo_set_embargo($pid, $list->lid, $expiry);
         drupal_set_message(t("Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
         watchdog('islandora_ip_embargo', "Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -1,0 +1,91 @@
+<?php
+
+function islandora_ip_embargo_drush_command(){
+    $items = array();
+    $items['islandora-ip-embargo-addRange'] = array(
+        'description' => 'Add a network address range to the embargo list.',
+        'options' => array(
+            'low' => array(
+                'description' => 'First address in the IP range (e.g, "172.16.0.0").',
+                'required' => 'TRUE',
+            ),
+            'high' => array(
+                'description' => 'Last address in the IP range (e.g., "172.16.255.255").',
+                'required' => 'TRUE',
+            ),
+            'list' => array(
+                'description' => 'Name of the list to add this range to (will be created if necessary).',
+                'required' => 'TRUE',
+            ),
+        ),
+        'aliases' => array('iipeadd'),
+    );
+    $items['islandora-ip-embargo-list-lists'] = array(
+        'description' => 'Returns all the network lists defined on the system.',
+        'aliases' => array('iipell'),
+    );
+    return $items;
+}
+
+
+function drush_islandora_ip_embargo_addRange(){
+    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+    $params = array(
+        'low' => drush_get_option('low'),
+        'high' => drush_get_option('high'),
+        'list' => drush_get_option('list'),
+    );
+
+    $low  = $params['low'];
+    $high = $params['high'];
+    // check that input vars are valid IPs
+    foreach(array($low, $high) as $ip){
+        if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
+            //drupal_set_message(t("!!! %i is NOT a valid IP address", array('%i' => $ip)), 'error');
+            drush_set_error("Invalid IP: $ip");
+            return;
+        }
+    }
+
+    // set up lists vars
+    $target_list = $params['list'];
+    $target_list_id = false;
+    $lists = islandora_ip_embargo_get_lists();
+
+    foreach($lists as $list){
+        if($target_list == $list->name){
+            $target_list_id = $list->lid;
+            if(is_duplicate_range($list->lid, $low, $high)){
+                return;
+            }
+            break;
+        }
+    }
+    if(!$target_list_id){
+        islandora_ip_embargo_add_list($target_list);
+        $target_list_id = islandora_ip_embargo_get_list_object_by_name($target_list)->lid;
+        drupal_set_message(t('Created list %l', array('%l'=> $target_list)));
+    }
+
+    islandora_ip_embargo_add_ip_range($target_list_id, $low, $high);
+}
+
+function is_duplicate_range($lid, $low, $high){
+    foreach(islandora_ip_embargo_get_ranges($lid) as $range){
+        if($range->low_end == $low && $range->high_end == $high){
+            drush_set_error("Duplicate IP range.");
+            return true;
+        }
+    }
+}
+
+
+function drush_islandora_ip_embargo_list_lists(){
+    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+
+    $lists = islandora_ip_embargo_get_lists();
+    printf("Network lists\n==============\n");
+    foreach($lists as $list){
+        printf("%s\n", $list->name);
+    }
+}

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -1,207 +1,200 @@
 <?php
 
 function islandora_ip_embargo_drush_command() {
-    $items = array();
-    $items['islandora-ip-embargo-addRange'] = array(
-        'description' => 'Add a network address range to the embargo list.',
-        'options' => array(
-            'low' => array(
-                'description' => 'First address in the IP range (e.g, "172.16.0.0").',
-                'required' => 'TRUE',
-            ),
-            'high' => array(
-                'description' => 'Last address in the IP range (e.g., "172.16.255.255").',
-                'required' => 'TRUE',
-            ),
-            'list' => array(
-                'description' => 'Name of the list to add this range to (will be created if necessary).',
-                'required' => 'TRUE',
-            ),
-        ),
-        'aliases' => array('iipeadd'),
-    );
-    $items['islandora-ip-embargo-list-lists'] = array(
-        'description' => 'Returns all the network lists defined on the system.',
-        'aliases' => array('iipell'),
-    );
-    $items['islandora-ip-embargo-set-embargo-for-item'] = array(
-        'description' => 'Set an embargo on an islandora object.',
-        'options' => array(
-            'pid' => array(
-                'description' => 'Islandora pid to embargo.',
-                'required' => 'TRUE',
-            ),
-            'list' => array(
-                'description' => 'Name of the IP list to use for the embargo.',
-                'required' => TRUE,
-            ),
-            'expiry' => array(
-                'description' => 'Date of expiry.',
-                'value' => 'optional',
-            ),
-        ),
-        'aliases' => array('iipese'),
-    );
-    $items['islandora-ip-embargo-set-embargo-from-pid-list'] = array(
-      'description' => dt('Create a collection container.'),
-      'examples' => array('drush islandora-utils-create-collection --parent=islandora:root --namespace=my:collection'),
-      'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
-      'drupal dependencies' => array(
-        'islandora',
-        'islandora_ip_embargo', //include version dependency ?
+  $items = array();
+  $items['islandora-ip-embargo-addRange'] = array(
+    'description' => 'Add a network address range to the embargo list.',
+    'options' => array(
+      'low' => array(
+        'description' => 'First address in the IP range (e.g, "172.16.0.0").',
+        'required' => 'TRUE',
       ),
-      'options' => array(
-        'pidsfile'  => array(
-          'description' => dt('File containing a comma-separated string of pids'),
-          'required'    => FALSE
-        ),
-        'lists' => array(
-          'description' => dt('comma-separated names of network lists to set.'),
-          'required' => TRUE,
-        ),
-        'expiry' => array(
-          dt("When to expire the embargo."),
-          'required' => FALSE,
-        )
+      'high' => array(
+        'description' => 'Last address in the IP range (e.g., "172.16.255.255").',
+        'required' => 'TRUE',
       ),
-    );
-    return $items;
+      'list' => array(
+        'description' => 'Name of the list to add this range to (will be created if necessary).',
+        'required' => 'TRUE',
+      ),
+    ),
+    'aliases' => array('iipeadd'),
+  );
+  $items['islandora-ip-embargo-list-lists'] = array(
+    'description' => 'Returns all the network lists defined on the system.',
+    'aliases' => array('iipell'),
+  );
+  $items['islandora-ip-embargo-set-embargo-for-item'] = array(
+    'description' => 'Set an embargo on an islandora object.',
+    'options' => array(
+      'pid' => array(
+        'description' => 'Islandora pid to embargo.',
+        'required' => 'TRUE',
+      ),
+      'list' => array(
+        'description' => 'Name of the IP list to use for the embargo.',
+        'required' => TRUE,
+      ),
+      'expiry' => array(
+        'description' => 'Date of expiry.',
+        'value' => 'optional',
+      ),
+    ),
+    'aliases' => array('iipese'),
+  );
+  $items['islandora-ip-embargo-set-embargo-from-pid-list'] = array(
+    'description' => dt('Create a collection container.'),
+    'examples' => array('drush islandora-utils-create-collection --parent=islandora:root --namespace=my:collection'),
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
+    'drupal dependencies' => array(
+      'islandora',
+      'islandora_ip_embargo', //include version dependency ?
+    ),
+    'options' => array(
+      'pidsfile' => array(
+        'description' => dt('File containing a comma-separated string of pids'),
+        'required' => FALSE
+      ),
+      'lists' => array(
+        'description' => dt('comma-separated names of network lists to set.'),
+        'required' => TRUE,
+      ),
+      'expiry' => array(
+        dt("When to expire the embargo."),
+        'required' => FALSE,
+      )
+    ),
+  );
+  return $items;
 }
 
-
 function drush_islandora_ip_embargo_addRange() {
-    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
-    $params = array(
-        'low' => drush_get_option('low'),
-        'high' => drush_get_option('high'),
-        'list' => drush_get_option('list'),
-    );
+  module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+  $params = array(
+    'low' => drush_get_option('low'),
+    'high' => drush_get_option('high'),
+    'list' => drush_get_option('list'),
+  );
 
-    $low  = $params['low'];
-    $high = $params['high'];
-    // check that input vars are valid IPs
-    foreach (array($low, $high) as $ip) {
-        if (filter_var($ip, FILTER_VALIDATE_IP) === FALSE) {
-            drush_set_error("Invalid IP: $ip");
-            return;
-        }
+  $low = $params['low'];
+  $high = $params['high'];
+  // check that input vars are valid IPs
+  foreach (array($low, $high) as $ip) {
+    if (filter_var($ip, FILTER_VALIDATE_IP) === FALSE) {
+      drush_set_error("Invalid IP: $ip");
+      return;
     }
+  }
 
-    // set up lists vars
-    $target_list = $params['list'];
-    $target_list_id = FALSE;
-    $lists = islandora_ip_embargo_get_lists();
+  // set up lists vars
+  $target_list = $params['list'];
+  $target_list_id = FALSE;
+  $lists = islandora_ip_embargo_get_lists();
 
-    foreach ($lists as $list) {
-        if ($target_list == $list->name) {
-            $target_list_id = $list->lid;
-            if(is_duplicate_range($list->lid, $low, $high)) {
-                return;
-            }
-            break;
-        }
+  foreach ($lists as $list) {
+    if ($target_list == $list->name) {
+      $target_list_id = $list->lid;
+      if (is_duplicate_range($list->lid, $low, $high)) {
+        return;
+      }
+      break;
     }
-    if (!$target_list_id) {
-        islandora_ip_embargo_add_list($target_list);
-        $target_list_id = islandora_ip_embargo_get_list_object_by('name', $target_list)->lid;
-        drupal_set_message(t('Created list %l', array('%l'=> $target_list)));
-    }
+  }
+  if (!$target_list_id) {
+    islandora_ip_embargo_add_list($target_list);
+    $target_list_id = islandora_ip_embargo_get_list_object_by('name', $target_list)->lid;
+    drupal_set_message(t('Created list %l', array('%l' => $target_list)));
+  }
 
-    islandora_ip_embargo_add_ip_range($target_list_id, $low, $high);
+  islandora_ip_embargo_add_ip_range($target_list_id, $low, $high);
 }
 
 function is_duplicate_range($lid, $low, $high) {
-    foreach (islandora_ip_embargo_get_ranges($lid) as $range) {
-        if ($range->low_end == $low && $range->high_end == $high) {
-            drupal_set_message(t("Duplicate IP range. Nothing changed."));
-            return TRUE;
-        }
+  foreach (islandora_ip_embargo_get_ranges($lid) as $range) {
+    if ($range->low_end == $low && $range->high_end == $high) {
+      drupal_set_message(t("Duplicate IP range. Nothing changed."));
+      return TRUE;
     }
+  }
 }
 
-
 function drush_islandora_ip_embargo_list_lists() {
-    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+  module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
 
-    $lists = islandora_ip_embargo_get_lists();
-    printf("Network lists\n==============\n");
-    foreach ($lists as $list) {
-        printf("%s\n", $list->name);
-        foreach (islandora_ip_embargo_get_ranges($list->lid) as $range) {
-            printf("%s - %s\n", $range->low_end, $range->high_end);
-        }
-        printf("\n");
+  $lists = islandora_ip_embargo_get_lists();
+  printf("Network lists\n==============\n");
+  foreach ($lists as $list) {
+    printf("%s\n", $list->name);
+    foreach (islandora_ip_embargo_get_ranges($list->lid) as $range) {
+      printf("%s - %s\n", $range->low_end, $range->high_end);
     }
+    printf("\n");
+  }
 }
 
 function drush_islandora_ip_embargo_set_embargo_for_item() {
-    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
-    $params = array(
-        'pid' => drush_get_option('pid'),
-        'list' => drush_get_option('list'),
-        'expiry' => drush_get_option('expiry'),
-    );
-    make_embargo_from_params($params);
+  module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+  $params = array(
+    'pid' => drush_get_option('pid'),
+    'list' => drush_get_option('list'),
+    'expiry' => drush_get_option('expiry'),
+  );
+  make_embargo_from_params($params);
 }
 
 function drush_islandora_ip_embargo_set_embargo_from_pid_list() {
-    $pids   = explode(',', file_get_contents(drush_get_option('pidsfile')));
-    $expiry = drush_get_option('expiry');
-    $lists  = explode(',', drush_get_option('lists'));
-    $params = array('expiry' => $expiry);
+  $pids = explode(',', file_get_contents(drush_get_option('pidsfile')));
+  $expiry = drush_get_option('expiry');
+  $lists = explode(',', drush_get_option('lists'));
+  $params = array('expiry' => $expiry);
 
-    foreach ($lists as $list) {
-        foreach ($pids as $pid) {
-            $params['pid'] = $pid;
-            $params['list'] = $list;
-            make_embargo_from_params($params);
-        }
+  foreach ($lists as $list) {
+    foreach ($pids as $pid) {
+      $params['pid'] = $pid;
+      $params['list'] = $list;
+      make_embargo_from_params($params);
     }
+  }
 }
 
 function make_embargo_from_params($params) {
-    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
-    $pid = $params['pid'];
-    $list = islandora_ip_embargo_get_list_object_by('name', $params['list']);
+  module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+  $pid = $params['pid'];
+  $list = islandora_ip_embargo_get_list_object_by('name', $params['list']);
 
-    // set up expiry date from params
-    if ($params['expiry'] !== NULL) {
-        $date_elements = explode('-', $params['expiry']);
-        if(count($date_elements) != 3){
-            drush_set_error("Expiry argument expects the date given as YYYY-MM-DD. Got $date_elements");
-            return;
-        }
-        $expiry_elements = array('year' => $date_elements[0], 'month' => $date_elements[1], 'day' => $date_elements[2]);
-        $expiry = mktime(
-          0,
-          0,
-          0,
-          $expiry_elements['month'],
-          $expiry_elements['day'],
-          $expiry_elements['year']
-        );
+  // set up expiry date from params
+  if ($params['expiry'] !== NULL) {
+    $date_elements = explode('-', $params['expiry']);
+    if (count($date_elements) != 3) {
+      drush_set_error("Expiry argument expects the date given as YYYY-MM-DD. Got $date_elements");
+      return;
     }
+    $expiry_elements = array('year' => $date_elements[0], 'month' => $date_elements[1], 'day' => $date_elements[2]);
+    $expiry = mktime(
+        0, 0, 0, $expiry_elements['month'], $expiry_elements['day'], $expiry_elements['year']
+    );
+  }
 
-    // check for good pid.
-    $object = islandora_object_load($pid);
-    if (!$object) {
-        //drupal_set_message(t("Object %p does not exist in this repository.", array('%p' => $pid)));
-    }
-    $exp_str = $expiry == NULL ? "Never" : $expiry;
+  // check for good pid.
+  $object = islandora_object_load($pid);
+  if (!$object) {
+  }
+  $exp_str = $expiry == NULL ? "Never" : $expiry;
 
-    // determine whether an embargo exists already for an object.
-    $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();
-    if ($update) {
-        if ($update->lid == $list->lid && $update->expiry == $expiry) {
-            drupal_set_message(t("No update required for IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-            return;
-        }
-        islandora_ip_embargo_update_embargo($pid, $list->lid, $expiry);
-        drupal_set_message(t("Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-        watchdog('islandora_ip_embargo', "Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
-    } else {
-        islandora_ip_embargo_set_embargo($pid, $list->lid, $expiry);
-        drupal_set_message(t("Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-        watchdog('islandora_ip_embargo', "Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+  // determine whether an embargo exists already for an object.
+  $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();
+  if ($update) {
+    if ($update->lid == $list->lid && $update->expiry == $expiry) {
+      drupal_set_message(t("No update required for IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+      return;
     }
+    islandora_ip_embargo_update_embargo($pid, $list->lid, $expiry);
+    drupal_set_message(t("Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+    watchdog('islandora_ip_embargo', "Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+  }
+  else {
+    islandora_ip_embargo_set_embargo($pid, $list->lid, $expiry);
+    drupal_set_message(t("Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+    watchdog('islandora_ip_embargo', "Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+  }
 }

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -1,5 +1,15 @@
 <?php
+/**
+ * @file
+ * Drush interface to ip_embargo functionality.
+ */
 
+/**
+ * Drush commands declaration.
+ *
+ * @return array
+ *   drush commands data
+ */
 function islandora_ip_embargo_drush_command() {
   $items = array();
   $items['islandora-ip-embargo-addRange'] = array(
@@ -48,26 +58,35 @@ function islandora_ip_embargo_drush_command() {
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
     'drupal dependencies' => array(
       'islandora',
-      'islandora_ip_embargo', //include version dependency ?
+      // Include version dependency ?
+      'islandora_ip_embargo',
     ),
     'options' => array(
       'pidsfile' => array(
         'description' => dt('File containing a comma-separated string of pids'),
-        'required' => FALSE
+        'required' => FALSE,
       ),
       'lists' => array(
         'description' => dt('comma-separated names of network lists to set.'),
         'required' => TRUE,
       ),
       'expiry' => array(
-        dt("When to expire the embargo."),
+        'description' => dt("When to expire the embargo."),
         'required' => FALSE,
-      )
+      ),
     ),
   );
   return $items;
 }
 
+/**
+ * Drush command; adds IP range to a named list.
+ *
+ * Creates the list if it does not already exist.
+ *
+ * @return NULL
+ *   no return
+ */
 function drush_islandora_ip_embargo_addRange() {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   $params = array(
@@ -78,7 +97,7 @@ function drush_islandora_ip_embargo_addRange() {
 
   $low = $params['low'];
   $high = $params['high'];
-  // check that input vars are valid IPs
+  // Check that input vars are valid IPs.
   foreach (array($low, $high) as $ip) {
     if (filter_var($ip, FILTER_VALIDATE_IP) === FALSE) {
       drush_set_error("Invalid IP: $ip");
@@ -86,7 +105,6 @@ function drush_islandora_ip_embargo_addRange() {
     }
   }
 
-  // set up lists vars
   $target_list = $params['list'];
   $target_list_id = FALSE;
   $lists = islandora_ip_embargo_get_lists();
@@ -109,6 +127,19 @@ function drush_islandora_ip_embargo_addRange() {
   islandora_ip_embargo_add_ip_range($target_list_id, $low, $high);
 }
 
+/**
+ * Check that record to be created is not already stored.
+ *
+ * @param int $lid
+ *   list ID
+ * @param string $low
+ *   IPV4 address that starts the allowed range.
+ * @param string $high
+ *   IPV4 address that ends the allowed range.
+ *
+ * @return bool
+ *   true if an existing record matches the one being tested.
+ */
 function is_duplicate_range($lid, $low, $high) {
   foreach (islandora_ip_embargo_get_ranges($lid) as $range) {
     if ($range->low_end == $low && $range->high_end == $high) {
@@ -118,6 +149,9 @@ function is_duplicate_range($lid, $low, $high) {
   }
 }
 
+/**
+ * Drush command; prints named lists and their constituent ranges to stdOut.
+ */
 function drush_islandora_ip_embargo_list_lists() {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
 
@@ -132,6 +166,9 @@ function drush_islandora_ip_embargo_list_lists() {
   }
 }
 
+/**
+ * Drush command; creates an embargo for the given pid.
+ */
 function drush_islandora_ip_embargo_set_embargo_for_item() {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   $params = array(
@@ -142,6 +179,11 @@ function drush_islandora_ip_embargo_set_embargo_for_item() {
   make_embargo_from_params($params);
 }
 
+/**
+ * Drush command; given a list of pids, embargo each.
+ *
+ * Similar to drush_islandora_ip_embargo_set_embargo_for_item();
+ */
 function drush_islandora_ip_embargo_set_embargo_from_pid_list() {
   $pids = explode(',', file_get_contents(drush_get_option('pidsfile')));
   $expiry = drush_get_option('expiry');
@@ -157,44 +199,95 @@ function drush_islandora_ip_embargo_set_embargo_from_pid_list() {
   }
 }
 
+/**
+ * Create an embargo based on the input params.
+ *
+ * @param array $params
+ *   key => value for keys (list,exiry,pid)
+ *
+ * @return NULL
+ *   no return
+ */
 function make_embargo_from_params($params) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   $pid = $params['pid'];
   $list = islandora_ip_embargo_get_list_object_by('name', $params['list']);
 
-  // set up expiry date from params
+  // Set up expiry date from params.
   if ($params['expiry'] !== NULL) {
     $date_elements = explode('-', $params['expiry']);
     if (count($date_elements) != 3) {
       drush_set_error("Expiry argument expects the date given as YYYY-MM-DD. Got $date_elements");
       return;
     }
-    $expiry_elements = array('year' => $date_elements[0], 'month' => $date_elements[1], 'day' => $date_elements[2]);
+    $expiry_elements = array(
+      'year' => $date_elements[0],
+      'month' => $date_elements[1],
+      'day' => $date_elements[2],
+    );
     $expiry = mktime(
         0, 0, 0, $expiry_elements['month'], $expiry_elements['day'], $expiry_elements['year']
     );
   }
 
-  // check for good pid.
+  // Check for good pid.
   $object = islandora_object_load($pid);
   if (!$object) {
   }
   $exp_str = $expiry == NULL ? "Never" : $expiry;
 
-  // determine whether an embargo exists already for an object.
+  // Determine whether an embargo exists already for an object.
   $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();
   if ($update) {
     if ($update->lid == $list->lid && $update->expiry == $expiry) {
-      drupal_set_message(t("No update required for IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-      return;
+      drupal_set_message(t(
+          "No update required for IP range list %list to Islandora object %obj, set to expire %exp",
+          array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str))
+      );
     }
     islandora_ip_embargo_update_embargo($pid, $list->lid, $expiry);
-    drupal_set_message(t("Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-    watchdog('islandora_ip_embargo', "Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+    drupal_set_message(
+        t(
+            "Updated IP range list %list to Islandora object %obj, set to expire %exp",
+            array(
+              '%list' => $params['list'],
+              '%obj' => $pid,
+              '%exp' => $exp_str,
+            )
+        )
+    );
+    watchdog(
+        'islandora_ip_embargo',
+        "Updated IP range list %list to Islandora object %obj, set to expire %exp",
+        array(
+          '%list' => $params['list'],
+          '%obj' => $pid,
+          '%exp' => $exp_str,
+        ),
+        WATCHDOG_NOTICE
+    );
   }
   else {
     islandora_ip_embargo_set_embargo($pid, $list->lid, $expiry);
-    drupal_set_message(t("Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
-    watchdog('islandora_ip_embargo', "Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list' => $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+    drupal_set_message(
+        t(
+            "Added IP range list %list to Islandora object %obj, set to expire %exp",
+            array(
+              '%list' => $params['list'],
+              '%obj' => $pid,
+              '%exp' => $exp_str,
+            )
+        )
+    );
+    watchdog(
+        'islandora_ip_embargo',
+        "Added IP range list %list to Islandora object %obj, set to expire %exp",
+        array(
+          '%list' => $params['list'],
+          '%obj' => $pid,
+          '%exp' => $exp_str,
+        ),
+        WATCHDOG_NOTICE
+    );
   }
 }

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -24,6 +24,24 @@ function islandora_ip_embargo_drush_command(){
         'description' => 'Returns all the network lists defined on the system.',
         'aliases' => array('iipell'),
     );
+    $items['islandora-ip-embargo-set-embargo-for-item'] = array(
+        'description' => 'Set an embargo on an islandora object.',
+        'options' => array(
+            'pid' => array(
+                'description' => 'Islandora pid to embargo.',
+                'required' => 'TRUE',
+            ),
+            'list' => array(
+                'description' => 'Name of the IP list to use for the embargo.',
+                'required' => TRUE,
+            ),
+            'expiry' => array(
+                'description' => 'Date of expiry.',
+                'value' => 'optional',
+            ),
+        ),
+        'aliases' => array('iipese'),
+    );
     return $items;
 }
 
@@ -63,7 +81,7 @@ function drush_islandora_ip_embargo_addRange(){
     }
     if(!$target_list_id){
         islandora_ip_embargo_add_list($target_list);
-        $target_list_id = islandora_ip_embargo_get_list_object_by_name($target_list)->lid;
+        $target_list_id = islandora_ip_embargo_get_list_object_by('name', $target_list)->lid;
         drupal_set_message(t('Created list %l', array('%l'=> $target_list)));
     }
 
@@ -87,5 +105,64 @@ function drush_islandora_ip_embargo_list_lists(){
     printf("Network lists\n==============\n");
     foreach($lists as $list){
         printf("%s\n", $list->name);
+        foreach(islandora_ip_embargo_get_ranges($list->lid) as $range){
+            printf("%s - %s\n", $range->low_end, $range->high_end);
+        }
+        printf("\n");
+    }
+}
+
+function drush_islandora_ip_embargo_set_embargo_for_item(){
+    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+    $params = array(
+        'pid' => drush_get_option('pid'),
+        'list' => drush_get_option('list'),
+        'expiry' => drush_get_option('expiry'),
+    );
+
+    $pid = $params['pid'];
+    $list = islandora_ip_embargo_get_list_object_by('name', $params['list']);
+
+    // set up expiry date from params
+    if($params['expiry'] !== NULL){
+        $date_elements = explode('-', $params['expiry']);
+        if(count($date_elements) != 3){
+            drush_set_error("Expiry argument expects the date given as YYYY-MM-DD. Got $date_elements");
+            return;
+        }
+        $expiry_elements = array('year' => $date_elements[0], 'month' => $date_elements[1], 'day' => $date_elements[2]);
+        $expiry = mktime(
+          0,
+          0,
+          0,
+          $expiry_elements['month'],
+          $expiry_elements['day'],
+          $expiry_elements['year']
+        );
+    }
+
+    // check for good pid.
+    $object = islandora_object_load($pid);
+    if(!$object){
+        drush_set_error("Object $pid does not exist in this repository.");
+        return;
+    }else{
+        $exp_str = $expiry == NULL ? "Never" : $expiry;
+
+        // determine whether an embargo exists already for an object.
+        $update = islandora_ip_embargo_get_embargo($pid)->fetchObject();
+        if($update){
+            if($update->lid == $list->lid && $update->expiry == $expiry){
+                drupal_set_message(t("No update required for IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+                return;
+            }
+            islandora_ip_embargo_update_embargo($pid, $list->lid, $expiry);
+            drupal_set_message(t("Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+            watchdog('islandora_ip_embargo', "Updated IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+        }else{
+            islandora_ip_embargo_set_embargo($pid, $list->lid, $expiry);
+            drupal_set_message(t("Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str)));
+            watchdog('islandora_ip_embargo', "Added IP range list %list to Islandora object %obj, set to expire %exp", array('%list'=> $params['list'], '%obj' => $pid, '%exp' => $exp_str), WATCHDOG_NOTICE);
+        }
     }
 }

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -146,7 +146,7 @@ function drush_islandora_ip_embargo_set_embargo_for_item(){
 }
 
 function drush_islandora_ip_embargo_set_embargo_from_pid_list(){
-    $pids   = explode(',', drush_get_option('pidsfile'));
+    $pids   = explode(',', file_get_contents(drush_get_option('pidsfile')));
     $expiry = drush_get_option('expiry');
     $lists  = explode(',', drush_get_option('lists'));
     $params = array('expiry' => $expiry);
@@ -161,6 +161,7 @@ function drush_islandora_ip_embargo_set_embargo_from_pid_list(){
 }
 
 function make_embargo_from_params($params){
+    module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
     $pid = $params['pid'];
     $list = islandora_ip_embargo_get_list_object_by('name', $params['list']);
 

--- a/islandora_ip_embargo.drush.inc
+++ b/islandora_ip_embargo.drush.inc
@@ -182,7 +182,7 @@ function drush_islandora_ip_embargo_set_embargo_for_item() {
 /**
  * Drush command; given a list of pids, embargo each.
  *
- * Similar to drush_islandora_ip_embargo_set_embargo_for_item();
+ * Similar to function drush_islandora_ip_embargo_set_embargo_for_item;
  */
 function drush_islandora_ip_embargo_set_embargo_from_pid_list() {
   $pids = explode(',', file_get_contents(drush_get_option('pidsfile')));


### PR DESCRIPTION
Introduces drush commands for manipulating the islandora_ip_embargo values within an Islandora.  

Includes: 
  -- listing the various Network Address Lists and IP Ranges
  -- creating new Network Address Lists & Ranges
  -- adding an IP Range to an existing Network Address List, and
  -- applying a Network Address List to a PID.

Also generalizes function islandora_ip_embargo_get_list_name($list_identifier)   into function islandora_ip_embargo_get_list_object_by($field, $value).  Now the function can lookup "lid" by "list_name" and vice versa.  
