### PR TITLE
Improved TN validation to be more reliable

### DIFF
--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -185,28 +185,23 @@ function islandora_ip_embargo_cron() {
 /**
  * Implements hook_preprocess_theme().
  *
- * Checks the path, if it's an Islandora TN DS then it uses JS to watermark
- * the resulting image.
+ * Determine if tokenized datastream is TN and add text if the parent
+ * is embargoed.
  */
 function islandora_ip_embargo_preprocess_image(&$variables) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
 
-  $image_path = parse_url($variables['path'], PHP_URL_PATH);
-  $image_path_parts = explode('/', $image_path);
-  $size_of_image_path = count($image_path_parts);
-  $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
-  $color = variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
+  $ds = menu_get_object('islandora_tokened_datastream', 4, $variables['path']);
 
-  if ($image_path_parts[$size_of_image_path - 1] == 'view' &&
-      $image_path_parts[$size_of_image_path - 2] == 'TN' &&
-      $image_path_parts[$size_of_image_path - 3] == 'datastream') {
-
-    $pid = urldecode($image_path_parts[$size_of_image_path - 4]);
-    $embargo_result = islandora_ip_embargo_get_embargo($pid);
+  if ($ds && $ds->id == 'TN') {
+    $embargo_result = islandora_ip_embargo_get_embargo($ds->parent->id);
 
     if ($embargo_result->rowCount()) {
+      $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
+      $color = variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
       drupal_add_js(drupal_get_path('module', 'islandora_ip_embargo') . '/js/embargoed_images.js');
       drupal_add_js(array('islandora_ip_embargo' => array('text' => $text, 'color' => $color)), array('type' => 'setting'));
+
       if (isset($variables['#attributes']['class'])) {
         $variables['attributes']['class'] = $variables['#attributes']['class']
           . 'islandora_ip_embargo_embargoed';


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1982

# What does this Pull Request do?
Provides a more reliable method of TN validation to watermark embargoed objects.

# Background context:
The usage of parse_url seen [here](https://github.com/Islandora-Labs/islandora_ip_embargo/blob/7.x/islandora_ip_embargo.module#L194) is used to explode on '/' and perform some processing/validation. It's been discovered that parse_url treats the pid bit of the path as ports and returns null for any pid values over 65535 (see [here](https://github.com/php/php-src/blob/7311087cf06bf9f3d6b5863d9b54272f3d163ba9/ext/standard/url.c#L193-L199)) which is resulting in no watermarked text being placed. This pull request provides a more reliable approach to do the validation and processing to place the watermarked text.

# How should this be tested?
Create 2 collections, one with a PID of something:65535 and something:65536. Place an embargo on both collections and you'll see that the embargoed text only appears on the something:65535 collection.

----
Brandon Morrissey
_Support Analyst_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**