### PR TITLE
Islandora-2005

### DIFF
--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -185,23 +185,28 @@ function islandora_ip_embargo_cron() {
 /**
  * Implements hook_preprocess_theme().
  *
- * Determine if tokenized datastream is TN and add text if the parent
- * is embargoed.
+ * Checks the path, if it's an Islandora TN DS then it uses JS to watermark
+ * the resulting image.
  */
 function islandora_ip_embargo_preprocess_image(&$variables) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
 
-  $ds = menu_get_object('islandora_tokened_datastream', 4, $variables['path']);
+  $image_path = parse_url($variables['path'], PHP_URL_PATH);
+  $image_path_parts = explode('/', $image_path);
+  $size_of_image_path = count($image_path_parts);
+  $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
+  $color = variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
 
-  if ($ds && $ds->id == 'TN') {
-    $embargo_result = islandora_ip_embargo_get_embargo($ds->parent->id);
+  if ($image_path_parts[$size_of_image_path - 1] == 'view' &&
+      $image_path_parts[$size_of_image_path - 2] == 'TN' &&
+      $image_path_parts[$size_of_image_path - 3] == 'datastream') {
+
+    $pid = urldecode($image_path_parts[$size_of_image_path - 4]);
+    $embargo_result = islandora_ip_embargo_get_embargo($pid);
 
     if ($embargo_result->rowCount()) {
-      $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
-      $color = variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
       drupal_add_js(drupal_get_path('module', 'islandora_ip_embargo') . '/js/embargoed_images.js');
       drupal_add_js(array('islandora_ip_embargo' => array('text' => $text, 'color' => $color)), array('type' => 'setting'));
-
       if (isset($variables['#attributes']['class'])) {
         $variables['attributes']['class'] = $variables['#attributes']['class']
           . 'islandora_ip_embargo_embargoed';

--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -190,12 +190,17 @@ function islandora_ip_embargo_cron() {
  */
 function islandora_ip_embargo_preprocess_image(&$variables) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
+  // XXX: We manually split up the URL here instead of using parse_url
+  // because the parse_url function interperates the : in the path as 
+  // a port number and chokes if the PID is > 65535. We want to keep this
+  // check as fast as we can because it could potentially be done a large 
+  // number of times in a large render array, so we don't want to load the
+  // whole islandora object, just to check the URL. 
 
-  $image_path = parse_url($variables['path'], PHP_URL_PATH);
+  // Strip the query parameters from URL.
+  $image_path = strtok($variables['path'], '?');
   $image_path_parts = explode('/', $image_path);
   $size_of_image_path = count($image_path_parts);
-  $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
-  $color = variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
 
   if ($image_path_parts[$size_of_image_path - 1] == 'view' &&
       $image_path_parts[$size_of_image_path - 2] == 'TN' &&
@@ -203,6 +208,9 @@ function islandora_ip_embargo_preprocess_image(&$variables) {
 
     $pid = urldecode($image_path_parts[$size_of_image_path - 4]);
     $embargo_result = islandora_ip_embargo_get_embargo($pid);
+
+    $text = variable_get('islandora_ip_embargo_overlay_text', 'EMBARGOED');
+    $color = variable_get('islandora_ip_embargo_overlay_text_color', 'FF0000');
 
     if ($embargo_result->rowCount()) {
       drupal_add_js(drupal_get_path('module', 'islandora_ip_embargo') . '/js/embargoed_images.js');

--- a/islandora_ip_embargo.module
+++ b/islandora_ip_embargo.module
@@ -191,11 +191,11 @@ function islandora_ip_embargo_cron() {
 function islandora_ip_embargo_preprocess_image(&$variables) {
   module_load_include('inc', 'islandora_ip_embargo', 'includes/utilities');
   // XXX: We manually split up the URL here instead of using parse_url
-  // because the parse_url function interperates the : in the path as 
+  // because the parse_url function interperates the : in the path as
   // a port number and chokes if the PID is > 65535. We want to keep this
-  // check as fast as we can because it could potentially be done a large 
+  // check as fast as we can because it could potentially be done a large
   // number of times in a large render array, so we don't want to load the
-  // whole islandora object, just to check the URL. 
+  // whole islandora object, just to check the URL.
 
   // Strip the query parameters from URL.
   $image_path = strtok($variables['path'], '?');


### PR DESCRIPTION
## JIRA Ticket:

https://jira.duraspace.org/browse/ISLANDORA-2005

Previous pull request: 
https://github.com/Islandora-Labs/islandora_ip_embargo/pull/28

## What does this Pull Request do?

Revert the work done in [ISLANDORA-1982](https://jira.duraspace.org/browse/ISLANDORA-1982) as the calls to menu_get_object are very expensive with a large render array. Fix issues with calling `parse_url`, by doing some small manual parsing. Add some comments about why this was done.

On a large compound object with 1000 children before this change `drupal_render` is taking 95.99% of the total execution time of the page after it was taking 8.62% of render time. 

## How should this be tested?

Create 2 collections, one with a PID of something:65535 and something:65536. Place an embargo on both collections and make sure that the embargo text still appears on both collections. 

# Additional Notes:

This largely reverts the work done in #28, opting to refine the code that was existing before.

# Interested parties
@Islandora/7-x-1-x-committers @BrandonMorr @bryjbrown 