### PR TITLE
Make IP address range list required when embargoing.

### DIFF
--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -448,7 +448,7 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
   $form_state['storage']['islandroa_ip_embargo']['update'] = FALSE;
   $form_state['storage']['islandroa_ip_embargo']['pid'] = $islandora_object->id;
   $list_results = islandora_ip_embargo_get_lists();
-  $options = array();
+  $options = array('none' => t('No IP Embargo'));
   while ($data = $list_results->fetchObject()) {
     $options[$data->lid] = $data->name;
   }
@@ -458,7 +458,7 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
     '#title' => 'IP address range list',
     '#description' => t('The list of IP ranges for which this object will be available.  Any other network address will be blocked.'),
     '#options' => $options,
-    '#required' => TRUE,
+    '#element_validate' => array('islandora_ip_embargo_ip_address_range_list_validate'),
   );
   $form['expiry_date'] = array(
     '#type' => 'date',
@@ -553,5 +553,21 @@ function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
   $color = $element['#value'];
   if (!(ctype_xdigit($color) && (strlen($color) === 6 || strlen($color) === 3))) {
     form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexideciamal format, requires 3 or 6 characters and A-F 0-9 characters apply (E.g. F0A3B1 or F1A).'));
+  }
+}
+
+/**
+ * Validate IP address range list when embargoing.
+ *
+ * @param array $element
+ *   The Drupal element data.
+ * @param array $form_state
+ *   The Drupal form state.
+ * @param array $form
+ *   The Drupal form definition.
+ */
+function  islandora_ip_embargo_ip_address_range_list_validate($element, &$form_state, $form) {
+  if (!$form_state['storage']['islandroa_ip_embargo']['update'] && ($element['#value'] == 'none')) {
+    form_set_error('islandora_ip_embargo_ip_address_list', t('This object was not previously embargoed, so setting the IP Address Range List to No IP Embargo does not change anything.'));
   }
 }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -566,7 +566,7 @@ function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
  * @param array $form
  *   The Drupal form definition.
  */
-function islandora_ip_embargo_ip_address_range_list_validate($element, array &$form_state, array $form) {
+function islandora_ip_embargo_ip_address_range_list_validate(array $element, array &$form_state, array $form) {
   if (!$form_state['storage']['islandroa_ip_embargo']['update'] && ($element['#value'] == 'none')) {
     form_set_error('islandora_ip_embargo_ip_address_list', t('This object was not previously embargoed, so setting the "IP address range list" to "No IP Embargo" does not change anything.'));
   }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -568,6 +568,6 @@ function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
  */
 function islandora_ip_embargo_ip_address_range_list_validate($element, &$form_state, $form) {
   if (!$form_state['storage']['islandroa_ip_embargo']['update'] && ($element['#value'] == 'none')) {
-    form_set_error('islandora_ip_embargo_ip_address_list', t('This object was not previously embargoed, so setting the IP Address Range List to No IP Embargo does not change anything.'));
+    form_set_error('islandora_ip_embargo_ip_address_list', t('This object was not previously embargoed, so setting the "IP address range list" to "No IP Embargo" does not change anything.'));
   }
 }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -54,7 +54,7 @@ function islandora_ip_embargo_settings_form($form, &$form_state) {
   $form['islandora_ip_embargo_overlay_text_color'] = array(
     '#type' => 'textfield',
     '#title' => t('Embargoed item overlay text color'),
-    '#description' => t('Overlay text color in hexideciamal format (E.g. FF0000 or F0A).'),
+    '#description' => t('Overlay text color in hexadecimal format (E.g. FF0000 or F0A).'),
     '#maxlength' => 6,
     '#required' => TRUE,
     '#element_validate' => array('islandora_ip_embargo_hex_validate'),
@@ -540,7 +540,7 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
 }
 
 /**
- * Validate hexidecimal color input.
+ * Validate hexadecimal color input.
  *
  * @param array $element
  *   The Drupal element data.
@@ -552,7 +552,7 @@ function islandora_ip_embargo_object_embargo_form_submit($form, &$form_state) {
 function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
   $color = $element['#value'];
   if (!(ctype_xdigit($color) && (strlen($color) === 6 || strlen($color) === 3))) {
-    form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexideciamal format, requires 3 or 6 characters and A-F 0-9 characters apply (E.g. F0A3B1 or F1A).'));
+    form_set_error('islandora_ip_embargo_overlay_text_color', t('Color must match hexadecimal format, requires 3 or 6 characters and A-F 0-9 characters apply (E.g. F0A3B1 or F1A).'));
   }
 }
 

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * This file holds forms for islandora_ip_embargo
+ * This file holds forms for islandora_ip_embargo.
  */
 
 /**
@@ -566,7 +566,7 @@ function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
  * @param array $form
  *   The Drupal form definition.
  */
-function  islandora_ip_embargo_ip_address_range_list_validate($element, &$form_state, $form) {
+function islandora_ip_embargo_ip_address_range_list_validate($element, &$form_state, $form) {
   if (!$form_state['storage']['islandroa_ip_embargo']['update'] && ($element['#value'] == 'none')) {
     form_set_error('islandora_ip_embargo_ip_address_list', t('This object was not previously embargoed, so setting the IP Address Range List to No IP Embargo does not change anything.'));
   }

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -448,7 +448,7 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
   $form_state['storage']['islandroa_ip_embargo']['update'] = FALSE;
   $form_state['storage']['islandroa_ip_embargo']['pid'] = $islandora_object->id;
   $list_results = islandora_ip_embargo_get_lists();
-  $options = array('none' => NULL);
+  $options = array();
   while ($data = $list_results->fetchObject()) {
     $options[$data->lid] = $data->name;
   }
@@ -458,6 +458,7 @@ function islandora_ip_embargo_object_embargo_form($form, &$form_state, $islandor
     '#title' => 'IP address range list',
     '#description' => t('The list of IP ranges for which this object will be available.  Any other network address will be blocked.'),
     '#options' => $options,
+    '#required' => TRUE,
   );
   $form['expiry_date'] = array(
     '#type' => 'date',

--- a/includes/forms.inc
+++ b/includes/forms.inc
@@ -566,7 +566,7 @@ function islandora_ip_embargo_hex_validate($element, &$form_state, $form) {
  * @param array $form
  *   The Drupal form definition.
  */
-function islandora_ip_embargo_ip_address_range_list_validate($element, &$form_state, $form) {
+function islandora_ip_embargo_ip_address_range_list_validate($element, array &$form_state, array $form) {
   if (!$form_state['storage']['islandroa_ip_embargo']['update'] && ($element['#value'] == 'none')) {
     form_set_error('islandora_ip_embargo_ip_address_list', t('This object was not previously embargoed, so setting the "IP address range list" to "No IP Embargo" does not change anything.'));
   }


### PR DESCRIPTION
**JIRA Ticket**: [ISLANDORA-2032](https://jira.duraspace.org/browse/ISLANDORA-2032)

# What does this Pull Request do?

Makes things not break when someone tries to embargo an item without an actual IP range list.

# What's new?
Makes the IP range list required, and makes it impossible to submit a null value.

# How should this be tested?

To reproduce the problem, try using IP Embargo to embargo an object without choosing an IP range list. Screenshot of the error is attached to the JIRA ticket.

This pull request should stop the form submission before it gets to the errors by making the field required.

# Interested parties
@Islandora/7-x-1-x-committers
