### PR TITLE
unpredictable behaviours, excuse the pun

### DIFF
--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -2,19 +2,22 @@
  * @file
  * Show the overlay text for embargoed items.
  */
-(function ($, Drupal, window, document, undefined) {
+(function ($) {
 Drupal.behaviors.islandora_ip_embargo = {
   attach: function(context, settings) {
-    $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
-    $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
-    $('span.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
-    $('span.islandora_ip_embargo_embargoed').css({
-      'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
-      'left' : '0',
-      'padding' : '0.5em',
-      'font-size' : '1.25em',
-      'position' : 'absolute',
-      'text-decoration' : 'none',
+    $('img.islandora_ip_embargo_embargoed', context).once('islandora-ip-embargo-overlay', function() {
+      $(this).wrap('<div style="position:relative;"></div>');
+      $(this).after('<span class="islandora_ip_embargo_embargoed"></span>');
+      $(this).nextAll('span:first')
+        .text(Drupal.t(Drupal.settings.islandora_ip_embargo.text))
+        .css({
+          'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
+          'left' : '0',
+          'padding' : '0.5em',
+          'font-size' : '1.25em',
+          'position' : 'absolute',
+          'text-decoration' : 'none',
+        });
     });
   }};
-})(jQuery, Drupal, this, this.document);
+})(jQuery);

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -5,18 +5,16 @@
 (function ($, Drupal, window, document, undefined) {
 Drupal.behaviors.islandora_ip_embargo = {
   attach: function(context, settings) {
-    $('.islandora_ip_embargo_embargoed').once('islandora-ip-embargo-overlay', function() {
-      $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
-      $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
-      $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
-      $('span.islandora_ip_embargo_embargoed').css({
-        'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
-        'left' : '0',
-        'padding' : '0.5em',
-        'font-size' : '1.25em',
-        'position' : 'absolute',
-        'text-decoration' : 'none',
-      });
+    $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
+    $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
+    $('span.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
+    $('span.islandora_ip_embargo_embargoed').css({
+      'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
+      'left' : '0',
+      'padding' : '0.5em',
+      'font-size' : '1.25em',
+      'position' : 'absolute',
+      'text-decoration' : 'none',
     });
   }};
 })(jQuery, Drupal, this, this.document);

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -5,16 +5,18 @@
 (function ($, Drupal, window, document, undefined) {
 Drupal.behaviors.islandora_ip_embargo = {
   attach: function(context, settings) {
-    $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
-    $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
-    $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
-    $('span.islandora_ip_embargo_embargoed').css({
-      'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
-      'left' : '0',
-      'padding' : '0.5em',
-      'font-size' : '1.25em',
-      'position' : 'absolute',
-      'text-decoration' : 'none',
+    $('.islandora_ip_embargo_embargoed').once('islandora-ip-embargo-overlay', function() {
+      $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
+      $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
+      $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
+      $('span.islandora_ip_embargo_embargoed').css({
+        'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
+        'left' : '0',
+        'padding' : '0.5em',
+        'font-size' : '1.25em',
+        'position' : 'absolute',
+        'text-decoration' : 'none',
+      });
     });
   }};
 })(jQuery, Drupal, this, this.document);

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -2,7 +2,7 @@
  * @file
  * Show the overlay text for embargoed items.
  */
-(function ($) {
+(function ($, Drupal) {
 Drupal.behaviors.islandora_ip_embargo = {
   attach: function(context, settings) {
     $('img.islandora_ip_embargo_embargoed', context).once('islandora-ip-embargo-overlay', function() {

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -20,4 +20,4 @@ Drupal.behaviors.islandora_ip_embargo = {
         });
     });
   }};
-})(jQuery);
+})(jQuery, Drupal);

--- a/js/embargoed_images.js
+++ b/js/embargoed_images.js
@@ -5,18 +5,16 @@
 (function ($, Drupal, window, document, undefined) {
 Drupal.behaviors.islandora_ip_embargo = {
   attach: function(context, settings) {
-    jQuery(document).ready(function($) {
-      $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
-      $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
-      $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
-      $('span.islandora_ip_embargo_embargoed').css({
-        'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
-        'left' : '0',
-        'padding' : '0.5em',
-        'font-size' : '1.25em',
-        'position' : 'absolute',
-        'text-decoration' : 'none',
-      });
+    $('.islandora_ip_embargo_embargoed').wrap('<div style="position:relative;"></div>');
+    $('.islandora_ip_embargo_embargoed').after('<span class="islandora_ip_embargo_embargoed"></span>');
+    $('.islandora_ip_embargo_embargoed').text(Drupal.t(Drupal.settings.islandora_ip_embargo.text));
+    $('span.islandora_ip_embargo_embargoed').css({
+      'color' : '#' + Drupal.settings.islandora_ip_embargo.color,
+      'left' : '0',
+      'padding' : '0.5em',
+      'font-size' : '1.25em',
+      'position' : 'absolute',
+      'text-decoration' : 'none',
     });
   }};
 })(jQuery, Drupal, this, this.document);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2095

# What does this Pull Request do?
Removes a call to `jQuery(document).ready()` nested inside a Drupal behavior.

There's details in the ticket, but the gist is that `jQuery(document).ready()` functions are only triggered once (when the document is ready), whereas Drupal behaviors can be triggered multiple times; this makes the document ready call kind of redundant, and it also means that it's possible for the nested document ready functionality to never trigger (e.g., if the behavior in question is acted upon as part of an AJAX callback).

# What's new?
That one removal.

# How should this be tested?
Recreating the exact conditions that make this issue crop up is a little difficult, but really just a regression test should be fine here. We should be able to:

* See the overlay text for any and all embargoed items
* Not see any other odd behaviours

@Islandora-Labs/committers 